### PR TITLE
Remove font smoothing

### DIFF
--- a/cigionline/static/css/_global.scss
+++ b/cigionline/static/css/_global.scss
@@ -1,6 +1,4 @@
 body {
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
   margin: 0;
 }
 


### PR DESCRIPTION
This isn't in our current site - it's leftover from when Foundation was installed here. Removing it so the font rendering looks the same.