### PR TITLE
Update person list page templates to use context

### DIFF
--- a/people/fixtures/people.json
+++ b/people/fixtures/people.json
@@ -119,7 +119,7 @@
     "slug": "experts",
     "content_type": ["people", "personlistpage"],
     "live": true,
-    "url_path": "/home/experts",
+    "url_path": "/home/experts/",
     "expired": false
   }
 }, {
@@ -161,7 +161,7 @@
     "slug": "board-member-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/board-member-live",
+    "url_path": "/home/people/board-member-live/",
     "expired": false
   }
 }, {
@@ -203,7 +203,7 @@
     "slug": "cigi-chair-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/cigi-chair-live",
+    "url_path": "/home/people/cigi-chair-live/",
     "expired": false
   }
 }, {
@@ -245,7 +245,7 @@
     "slug": "commision-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/commision-live",
+    "url_path": "/home/people/commision-live/",
     "expired": false
   }
 }, {
@@ -287,7 +287,7 @@
     "slug": "expert-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/expert-live",
+    "url_path": "/home/people/expert-live/",
     "expired": false
   }
 }, {
@@ -329,7 +329,7 @@
     "slug": "external-profile-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/external-profile-live",
+    "url_path": "/home/people/external-profile-live/",
     "expired": false
   }
 }, {
@@ -371,7 +371,7 @@
     "slug": "g20-expert-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/g20-expert-live",
+    "url_path": "/home/people/g20-expert-live/",
     "expired": false
   }
 }, {
@@ -413,7 +413,7 @@
     "slug": "management-team-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/management-team-live",
+    "url_path": "/home/people/management-team-live/",
     "expired": false
   }
 }, {
@@ -455,7 +455,7 @@
     "slug": "media-contact-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/media-contact-live",
+    "url_path": "/home/people/media-contact-live/",
     "expired": false
   }
 }, {
@@ -497,7 +497,7 @@
     "slug": "person-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/person-live",
+    "url_path": "/home/people/person-live/",
     "expired": false
   }
 }, {
@@ -539,7 +539,7 @@
     "slug": "program-director-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/program-director-live",
+    "url_path": "/home/people/program-director-live/",
     "expired": false
   }
 }, {
@@ -581,7 +581,7 @@
     "slug": "program-manager-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/program-manager-live",
+    "url_path": "/home/people/program-manager-live/",
     "expired": false
   }
 }, {
@@ -623,7 +623,7 @@
     "slug": "research-advisor-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/research-advisor-live",
+    "url_path": "/home/people/research-advisor-live/",
     "expired": false
   }
 }, {
@@ -665,7 +665,7 @@
     "slug": "research-associate-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/research-associate-live",
+    "url_path": "/home/people/research-associate-live/",
     "expired": false
   }
 }, {
@@ -707,7 +707,7 @@
     "slug": "research-fellow-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/research-fellow-live",
+    "url_path": "/home/people/research-fellow-live/",
     "expired": false
   }
 }, {
@@ -749,7 +749,7 @@
     "slug": "speaker-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/speaker-live",
+    "url_path": "/home/people/speaker-live/",
     "expired": false
   }
 }, {
@@ -791,7 +791,7 @@
     "slug": "staff-live",
     "content_type": ["people", "personpage"],
     "live": true,
-    "url_path": "/home/people/staff-live",
+    "url_path": "/home/people/staff-live/",
     "expired": false
   }
 }, {

--- a/people/models.py
+++ b/people/models.py
@@ -46,41 +46,35 @@ class PersonListPage(BasicPageAbstract):
     subpage_types = []
     templates = 'people/person_list_page.html'
 
-    class Meta:
-        verbose_name = 'Person List Page'
-        verbose_name_plural = 'Person List Pages'
+    def get_context(self, request):
+        context = super().get_context(request)
 
-    @property
-    def board_members(self):
-        if self.person_list_page_type == PersonListPage.PersonListPageType.LEADERSHIP:
-            return PersonPage.objects.live().filter(
-                archive=ArchiveablePageAbstract.ArchiveStatus.UNARCHIVED,
-                person_types__name='Board Member',
-            ).order_by(Unaccent(Lower('last_name')), Unaccent(Lower('first_name')))
-        return []
-
-    @property
-    def person_pages(self):
+        people = []
         if self.person_list_page_type == PersonListPage.PersonListPageType.EXPERTS:
-            return PersonPage.objects.live().filter(
+            people = PersonPage.objects.live().filter(
                 archive=ArchiveablePageAbstract.ArchiveStatus.UNARCHIVED,
                 person_types__name__in=['CIGI Chair', 'Expert'],
             ).order_by(Unaccent(Lower('last_name')), Unaccent(Lower('first_name')))
         elif self.person_list_page_type == PersonListPage.PersonListPageType.STAFF:
-            return PersonPage.objects.live().filter(
+            people = PersonPage.objects.live().filter(
                 archive=ArchiveablePageAbstract.ArchiveStatus.UNARCHIVED,
                 person_types__name='Staff',
             ).order_by(Unaccent(Lower('last_name')), Unaccent(Lower('first_name')))
-        return []
+        elif self.person_list_page_type == PersonListPage.PersonListPageType.LEADERSHIP:
+            show = request.GET.get('show')
+            if show == 'senior-management':
+                people = PersonPage.objects.live().filter(
+                    archive=ArchiveablePageAbstract.ArchiveStatus.UNARCHIVED,
+                    person_types__name='Management Team',
+                ).order_by(Unaccent(Lower('last_name')), Unaccent(Lower('first_name')))
+            else:
+                people = PersonPage.objects.live().filter(
+                    archive=ArchiveablePageAbstract.ArchiveStatus.UNARCHIVED,
+                    person_types__name='Board Member',
+                ).order_by(Unaccent(Lower('last_name')), Unaccent(Lower('first_name')))
+        context['people'] = people
 
-    @property
-    def senior_management(self):
-        if self.person_list_page_type == PersonListPage.PersonListPageType.LEADERSHIP:
-            return PersonPage.objects.live().filter(
-                archive=ArchiveablePageAbstract.ArchiveStatus.UNARCHIVED,
-                person_types__name='Management Team',
-            ).order_by(Unaccent(Lower('last_name')), Unaccent(Lower('first_name')))
-        return []
+        return context
 
     def get_template(self, request, *args, **kwargs):
         original_template = super(PersonListPage, self).get_template(request, *args, **kwargs)
@@ -91,6 +85,10 @@ class PersonListPage(BasicPageAbstract):
         elif self.person_list_page_type == PersonListPage.PersonListPageType.LEADERSHIP:
             return 'people/person_list_leadership_page.html'
         return original_template
+
+    class Meta:
+        verbose_name = 'Person List Page'
+        verbose_name_plural = 'Person List Pages'
 
 
 class PersonPage(ArchiveablePageAbstract):

--- a/people/models.py
+++ b/people/models.py
@@ -107,10 +107,6 @@ class PersonPage(ArchiveablePageAbstract):
         THESIS = 'Thesis'
         WEB_PAGE = 'Web Page'
 
-    @property
-    def topics(self):
-        return self.topics.live().order_by('title')
-
     address_city = models.CharField(blank=True, max_length=255)
     address_country = models.CharField(blank=True, max_length=255)
     address_line1 = models.CharField(blank=True, max_length=255)

--- a/people/tests.py
+++ b/people/tests.py
@@ -41,7 +41,7 @@ class PeoplePageTests(WagtailPageTests):
                 raise ae
 
 
-class PersonListPageTests(WagtailPageTests):
+class PersonListPageBasicTests(WagtailPageTests):
     fixtures = ["people.json"]
 
     def test_personlistpage_parent_page_types(self):
@@ -70,260 +70,273 @@ class PersonListPageTests(WagtailPageTests):
             else:
                 raise ae
 
+
+class PersonListPageRequestTests(WagtailPageTests):
+    fixtures = ["people.json"]
+
+    def setUp(self):
+        home_page = HomePage.objects.get()
+        home_page.numchild = 4
+        home_page.save()
+
+    def test_experts_page_returns_200(self):
+        response = self.client.get('/experts/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'people/person_list_experts_page.html')
+
+    def test_staff_page_returns_200(self):
+        response = self.client.get('/staff/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'people/person_list_staff_page.html')
+
+    def test_leadership_page_returns_200(self):
+        response = self.client.get('/leadership/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'people/person_list_leadership_page.html')
+
     def test_experts_page_should_not_show_live_board_member(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         board_member_live = PersonPage.objects.get(title='Board Member Live')
-        self.assertNotIn(board_member_live, experts_page.person_pages)
+        self.assertNotIn(board_member_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_board_member(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         board_member_archived = PersonPage.objects.get(title='Board Member Archived')
-        self.assertNotIn(board_member_archived, experts_page.person_pages)
+        self.assertNotIn(board_member_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_board_member(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         board_member_draft = PersonPage.objects.get(title='Board Member Draft')
-        self.assertNotIn(board_member_draft, experts_page.person_pages)
+        self.assertNotIn(board_member_draft, response.context['people'])
 
     def test_experts_page_should_show_live_cigi_chair(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         cigi_chair_live = PersonPage.objects.get(title='CIGI Chair Live')
-        self.assertIn(cigi_chair_live, experts_page.person_pages)
+        self.assertIn(cigi_chair_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_cigi_chair(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         cigi_chair_archived = PersonPage.objects.get(title='CIGI Chair Archived')
-        self.assertNotIn(cigi_chair_archived, experts_page.person_pages)
+        self.assertNotIn(cigi_chair_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_cigi_chair(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         cigi_chair_draft = PersonPage.objects.get(title='CIGI Chair Draft')
-        self.assertNotIn(cigi_chair_draft, experts_page.person_pages)
+        self.assertNotIn(cigi_chair_draft, response.context['people'])
 
     def test_experts_page_should_not_should_live_commission(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         commission_live = PersonPage.objects.get(title='Commission Live')
-        self.assertNotIn(commission_live, experts_page.person_pages)
+        self.assertNotIn(commission_live, response.context['people'])
 
     def test_experts_page_should_not_should_archived_commission(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         commission_archived = PersonPage.objects.get(title='Commission Archived')
-        self.assertNotIn(commission_archived, experts_page.person_pages)
+        self.assertNotIn(commission_archived, response.context['people'])
 
     def test_experts_page_should_not_should_draft_commission(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         commission_draft = PersonPage.objects.get(title='Commission Draft')
-        self.assertNotIn(commission_draft, experts_page.person_pages)
+        self.assertNotIn(commission_draft, response.context['people'])
 
     def test_experts_page_should_show_live_expert(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         expert_live = PersonPage.objects.get(title='Expert Live')
-        self.assertIn(expert_live, experts_page.person_pages)
+        self.assertIn(expert_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_expert(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         expert_archived = PersonPage.objects.get(title='Expert Archived')
-        self.assertNotIn(expert_archived, experts_page.person_pages)
+        self.assertNotIn(expert_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_expert(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         expert_draft = PersonPage.objects.get(title='Expert Draft')
-        self.assertNotIn(expert_draft, experts_page.person_pages)
+        self.assertNotIn(expert_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_external_profile(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         external_profile_live = PersonPage.objects.get(title='External profile Live')
-        self.assertNotIn(external_profile_live, experts_page.person_pages)
+        self.assertNotIn(external_profile_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_external_profile(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         external_profile_archived = PersonPage.objects.get(title='External profile Archived')
-        self.assertNotIn(external_profile_archived, experts_page.person_pages)
+        self.assertNotIn(external_profile_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_external_profile(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         external_profile_draft = PersonPage.objects.get(title='External profile Draft')
-        self.assertNotIn(external_profile_draft, experts_page.person_pages)
+        self.assertNotIn(external_profile_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_g20_expert(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         g20_expert_live = PersonPage.objects.get(title='G20 Expert Live')
-        self.assertNotIn(g20_expert_live, experts_page.person_pages)
+        self.assertNotIn(g20_expert_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_g20_expert(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         g20_expert_archived = PersonPage.objects.get(title='G20 Expert Archived')
-        self.assertNotIn(g20_expert_archived, experts_page.person_pages)
+        self.assertNotIn(g20_expert_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_g20_expert(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         g20_expert_draft = PersonPage.objects.get(title='G20 Expert Draft')
-        self.assertNotIn(g20_expert_draft, experts_page.person_pages)
+        self.assertNotIn(g20_expert_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_management_team(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         management_team_live = PersonPage.objects.get(title='Management Team Live')
-        self.assertNotIn(management_team_live, experts_page.person_pages)
+        self.assertNotIn(management_team_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_management_team(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         management_team_archived = PersonPage.objects.get(title='Management Team Archived')
-        self.assertNotIn(management_team_archived, experts_page.person_pages)
+        self.assertNotIn(management_team_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_management_team(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         management_team_draft = PersonPage.objects.get(title='Management Team Draft')
-        self.assertNotIn(management_team_draft, experts_page.person_pages)
+        self.assertNotIn(management_team_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_media_contact(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         media_contact_live = PersonPage.objects.get(title='Media Contact Live')
-        self.assertNotIn(media_contact_live, experts_page.person_pages)
+        self.assertNotIn(media_contact_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_media_contact(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         media_contact_archived = PersonPage.objects.get(title='Media Contact Archived')
-        self.assertNotIn(media_contact_archived, experts_page.person_pages)
+        self.assertNotIn(media_contact_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_media_contact(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         media_contact_draft = PersonPage.objects.get(title='Media Contact Draft')
-        self.assertNotIn(media_contact_draft, experts_page.person_pages)
+        self.assertNotIn(media_contact_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_person(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         person_live = PersonPage.objects.get(title='Person Live')
-        self.assertNotIn(person_live, experts_page.person_pages)
+        self.assertNotIn(person_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_person(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         person_archived = PersonPage.objects.get(title='Person Archived')
-        self.assertNotIn(person_archived, experts_page.person_pages)
+        self.assertNotIn(person_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_person(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         person_draft = PersonPage.objects.get(title='Person Draft')
-        self.assertNotIn(person_draft, experts_page.person_pages)
+        self.assertNotIn(person_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_program_director(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         program_director_live = PersonPage.objects.get(title='Program Director Live')
-        self.assertNotIn(program_director_live, experts_page.person_pages)
+        self.assertNotIn(program_director_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_program_director(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         program_director_archived = PersonPage.objects.get(title='Program Director Archived')
-        self.assertNotIn(program_director_archived, experts_page.person_pages)
+        self.assertNotIn(program_director_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_program_director(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         program_director_draft = PersonPage.objects.get(title='Program Director Draft')
-        self.assertNotIn(program_director_draft, experts_page.person_pages)
+        self.assertNotIn(program_director_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_program_manager(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         program_manager_live = PersonPage.objects.get(title='Program Manager Live')
-        self.assertNotIn(program_manager_live, experts_page.person_pages)
+        self.assertNotIn(program_manager_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_program_manager(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         program_manager_archived = PersonPage.objects.get(title='Program Manager Archived')
-        self.assertNotIn(program_manager_archived, experts_page.person_pages)
+        self.assertNotIn(program_manager_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_program_manager(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         program_manager_draft = PersonPage.objects.get(title='Program Manager Draft')
-        self.assertNotIn(program_manager_draft, experts_page.person_pages)
+        self.assertNotIn(program_manager_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_research_advisor(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_advisor_live = PersonPage.objects.get(title='Research Advisor Live')
-        self.assertNotIn(research_advisor_live, experts_page.person_pages)
+        self.assertNotIn(research_advisor_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_research_advisor(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_advisor_archived = PersonPage.objects.get(title='Research Advisor Archived')
-        self.assertNotIn(research_advisor_archived, experts_page.person_pages)
+        self.assertNotIn(research_advisor_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_research_advisor(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_advisor_draft = PersonPage.objects.get(title='Research Advisor Draft')
-        self.assertNotIn(research_advisor_draft, experts_page.person_pages)
+        self.assertNotIn(research_advisor_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_research_associate(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_associate_live = PersonPage.objects.get(title='Research Associate Live')
-        self.assertNotIn(research_associate_live, experts_page.person_pages)
+        self.assertNotIn(research_associate_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_research_associate(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_associate_archived = PersonPage.objects.get(title='Research Associate Archived')
-        self.assertNotIn(research_associate_archived, experts_page.person_pages)
+        self.assertNotIn(research_associate_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_research_associate(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_associate_draft = PersonPage.objects.get(title='Research Associate Draft')
-        self.assertNotIn(research_associate_draft, experts_page.person_pages)
+        self.assertNotIn(research_associate_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_research_fellow(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_fellow_live = PersonPage.objects.get(title='Research Fellow Live')
-        self.assertNotIn(research_fellow_live, experts_page.person_pages)
+        self.assertNotIn(research_fellow_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_research_fellow(self):
-
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_fellow_archived = PersonPage.objects.get(title='Research Fellow Archived')
-        self.assertNotIn(research_fellow_archived, experts_page.person_pages)
+        self.assertNotIn(research_fellow_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_research_fellow(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         research_fellow_draft = PersonPage.objects.get(title='Research Fellow Draft')
-        self.assertNotIn(research_fellow_draft, experts_page.person_pages)
+        self.assertNotIn(research_fellow_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_speaker(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         speaker_live = PersonPage.objects.get(title='Speaker Live')
-        self.assertNotIn(speaker_live, experts_page.person_pages)
+        self.assertNotIn(speaker_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_speaker(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         speaker_archived = PersonPage.objects.get(title='Speaker Archived')
-        self.assertNotIn(speaker_archived, experts_page.person_pages)
+        self.assertNotIn(speaker_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_speaker(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         speaker_draft = PersonPage.objects.get(title='Speaker Draft')
-        self.assertNotIn(speaker_draft, experts_page.person_pages)
+        self.assertNotIn(speaker_draft, response.context['people'])
 
     def test_experts_page_should_not_show_live_staff(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         staff_live = PersonPage.objects.get(title='Staff Live')
-        self.assertNotIn(staff_live, experts_page.person_pages)
+        self.assertNotIn(staff_live, response.context['people'])
 
     def test_experts_page_should_not_show_archived_staff(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         staff_archived = PersonPage.objects.get(title='Staff Archived')
-        self.assertNotIn(staff_archived, experts_page.person_pages)
+        self.assertNotIn(staff_archived, response.context['people'])
 
     def test_experts_page_should_not_show_draft_staff(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
+        response = self.client.get('/experts/')
         staff_draft = PersonPage.objects.get(title='Staff Draft')
-        self.assertNotIn(staff_draft, experts_page.person_pages)
+        self.assertNotIn(staff_draft, response.context['people'])
 
     def test_experts_page_order_accent_insensitive(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
-        expert_pages = list(experts_page.person_pages)
+        response = self.client.get('/experts/')
+        expert_pages = list(response.context['people'])
         kimi_raikkonen = PersonPage.objects.get(title='Kimi Räikkönen')
         daniel_ricciardo = PersonPage.objects.get(title='Daniel Ricciardo')
         self.assertIn(kimi_raikkonen, expert_pages)
@@ -333,257 +346,249 @@ class PersonListPageTests(WagtailPageTests):
             expert_pages.index(daniel_ricciardo),
         )
 
-    def test_experts_page_should_not_show_board_members(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
-        self.assertEqual(list(experts_page.board_members), [])
-
-    def test_experts_page_should_not_show_senior_management(self):
-        experts_page = PersonListPage.objects.get(title='Experts')
-        self.assertEqual(list(experts_page.senior_management), [])
-
     def test_staff_directory_page_should_not_show_live_board_member(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         board_member_live = PersonPage.objects.get(title='Board Member Live')
-        self.assertNotIn(board_member_live, staff_directory_page.person_pages)
+        self.assertNotIn(board_member_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_board_member(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         board_member_archived = PersonPage.objects.get(title='Board Member Archived')
-        self.assertNotIn(board_member_archived, staff_directory_page.person_pages)
+        self.assertNotIn(board_member_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_board_member(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         board_member_draft = PersonPage.objects.get(title='Board Member Draft')
-        self.assertNotIn(board_member_draft, staff_directory_page.person_pages)
+        self.assertNotIn(board_member_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_cigi_chair(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         cigi_chair_live = PersonPage.objects.get(title='CIGI Chair Live')
-        self.assertNotIn(cigi_chair_live, staff_directory_page.person_pages)
+        self.assertNotIn(cigi_chair_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_cigi_chair(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         cigi_chair_archived = PersonPage.objects.get(title='CIGI Chair Archived')
-        self.assertNotIn(cigi_chair_archived, staff_directory_page.person_pages)
+        self.assertNotIn(cigi_chair_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_cigi_chair(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         cigi_chair_draft = PersonPage.objects.get(title='CIGI Chair Draft')
-        self.assertNotIn(cigi_chair_draft, staff_directory_page.person_pages)
+        self.assertNotIn(cigi_chair_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_commission(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         commission_live = PersonPage.objects.get(title='Commission Live')
-        self.assertNotIn(commission_live, staff_directory_page.person_pages)
+        self.assertNotIn(commission_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_commission(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         commission_archived = PersonPage.objects.get(title='Commission Archived')
-        self.assertNotIn(commission_archived, staff_directory_page.person_pages)
+        self.assertNotIn(commission_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_commission(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         commission_draft = PersonPage.objects.get(title='Commission Draft')
-        self.assertNotIn(commission_draft, staff_directory_page.person_pages)
+        self.assertNotIn(commission_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_expert(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         expert_live = PersonPage.objects.get(title='Expert Live')
-        self.assertNotIn(expert_live, staff_directory_page.person_pages)
+        self.assertNotIn(expert_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_expert(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         expert_archived = PersonPage.objects.get(title='Expert Archived')
-        self.assertNotIn(expert_archived, staff_directory_page.person_pages)
+        self.assertNotIn(expert_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_expert(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         expert_draft = PersonPage.objects.get(title='Expert Draft')
-        self.assertNotIn(expert_draft, staff_directory_page.person_pages)
+        self.assertNotIn(expert_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_external_profile(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         external_profile_live = PersonPage.objects.get(title='External profile Live')
-        self.assertNotIn(external_profile_live, staff_directory_page.person_pages)
+        self.assertNotIn(external_profile_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_external_profile(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         external_profile_archived = PersonPage.objects.get(title='External profile Archived')
-        self.assertNotIn(external_profile_archived, staff_directory_page.person_pages)
+        self.assertNotIn(external_profile_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_external_profile(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         external_profile_draft = PersonPage.objects.get(title='External profile Draft')
-        self.assertNotIn(external_profile_draft, staff_directory_page.person_pages)
+        self.assertNotIn(external_profile_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_g20_expert(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         g20_expert_live = PersonPage.objects.get(title='G20 Expert Live')
-        self.assertNotIn(g20_expert_live, staff_directory_page.person_pages)
+        self.assertNotIn(g20_expert_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_g20_expert(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         g20_expert_archived = PersonPage.objects.get(title='G20 Expert Archived')
-        self.assertNotIn(g20_expert_archived, staff_directory_page.person_pages)
+        self.assertNotIn(g20_expert_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_g20_expert(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         g20_expert_draft = PersonPage.objects.get(title='G20 Expert Draft')
-        self.assertNotIn(g20_expert_draft, staff_directory_page.person_pages)
+        self.assertNotIn(g20_expert_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_management_team(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         management_team_live = PersonPage.objects.get(title='Management Team Live')
-        self.assertNotIn(management_team_live, staff_directory_page.person_pages)
+        self.assertNotIn(management_team_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_management_team(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         management_team_archived = PersonPage.objects.get(title='Management Team Archived')
-        self.assertNotIn(management_team_archived, staff_directory_page.person_pages)
+        self.assertNotIn(management_team_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_management_team(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         management_team_draft = PersonPage.objects.get(title='Management Team Draft')
-        self.assertNotIn(management_team_draft, staff_directory_page.person_pages)
+        self.assertNotIn(management_team_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_media_contact(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         media_contact_live = PersonPage.objects.get(title='Media Contact Live')
-        self.assertNotIn(media_contact_live, staff_directory_page.person_pages)
+        self.assertNotIn(media_contact_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_media_contact(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         media_contact_archived = PersonPage.objects.get(title='Media Contact Archived')
-        self.assertNotIn(media_contact_archived, staff_directory_page.person_pages)
+        self.assertNotIn(media_contact_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_media_contact(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         media_contact_draft = PersonPage.objects.get(title='Media Contact Draft')
-        self.assertNotIn(media_contact_draft, staff_directory_page.person_pages)
+        self.assertNotIn(media_contact_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_person(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         person_live = PersonPage.objects.get(title='Person Live')
-        self.assertNotIn(person_live, staff_directory_page.person_pages)
+        self.assertNotIn(person_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_person(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         person_archived = PersonPage.objects.get(title='Person Archived')
-        self.assertNotIn(person_archived, staff_directory_page.person_pages)
+        self.assertNotIn(person_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_person(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         person_draft = PersonPage.objects.get(title='Person Draft')
-        self.assertNotIn(person_draft, staff_directory_page.person_pages)
+        self.assertNotIn(person_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_program_director(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         program_director_live = PersonPage.objects.get(title='Program Director Live')
-        self.assertNotIn(program_director_live, staff_directory_page.person_pages)
+        self.assertNotIn(program_director_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_program_director(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         program_director_archived = PersonPage.objects.get(title='Program Director Archived')
-        self.assertNotIn(program_director_archived, staff_directory_page.person_pages)
+        self.assertNotIn(program_director_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_program_director(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         program_director_draft = PersonPage.objects.get(title='Program Director Draft')
-        self.assertNotIn(program_director_draft, staff_directory_page.person_pages)
+        self.assertNotIn(program_director_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_program_manager(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         program_manager_live = PersonPage.objects.get(title='Program Manager Live')
-        self.assertNotIn(program_manager_live, staff_directory_page.person_pages)
+        self.assertNotIn(program_manager_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_program_manager(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         program_manager_archived = PersonPage.objects.get(title='Program Manager Archived')
-        self.assertNotIn(program_manager_archived, staff_directory_page.person_pages)
+        self.assertNotIn(program_manager_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_program_manager(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         program_manager_draft = PersonPage.objects.get(title='Program Manager Draft')
-        self.assertNotIn(program_manager_draft, staff_directory_page.person_pages)
+        self.assertNotIn(program_manager_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_research_advisor(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_advisor_live = PersonPage.objects.get(title='Research Advisor Live')
-        self.assertNotIn(research_advisor_live, staff_directory_page.person_pages)
+        self.assertNotIn(research_advisor_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_research_advisor(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_advisor_archived = PersonPage.objects.get(title='Research Advisor Archived')
-        self.assertNotIn(research_advisor_archived, staff_directory_page.person_pages)
+        self.assertNotIn(research_advisor_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_research_advisor(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_advisor_draft = PersonPage.objects.get(title='Research Advisor Draft')
-        self.assertNotIn(research_advisor_draft, staff_directory_page.person_pages)
+        self.assertNotIn(research_advisor_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_research_associate(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_associate_live = PersonPage.objects.get(title='Research Associate Live')
-        self.assertNotIn(research_associate_live, staff_directory_page.person_pages)
+        self.assertNotIn(research_associate_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_research_associate(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_associate_archived = PersonPage.objects.get(title='Research Associate Archived')
-        self.assertNotIn(research_associate_archived, staff_directory_page.person_pages)
+        self.assertNotIn(research_associate_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_research_associate(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_associate_draft = PersonPage.objects.get(title='Research Associate Draft')
-        self.assertNotIn(research_associate_draft, staff_directory_page.person_pages)
+        self.assertNotIn(research_associate_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_research_fellow(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_fellow_live = PersonPage.objects.get(title='Research Fellow Live')
-        self.assertNotIn(research_fellow_live, staff_directory_page.person_pages)
+        self.assertNotIn(research_fellow_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_research_fellow(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_fellow_archived = PersonPage.objects.get(title='Research Fellow Archived')
-        self.assertNotIn(research_fellow_archived, staff_directory_page.person_pages)
+        self.assertNotIn(research_fellow_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_research_fellow(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         research_fellow_draft = PersonPage.objects.get(title='Research Fellow Draft')
-        self.assertNotIn(research_fellow_draft, staff_directory_page.person_pages)
+        self.assertNotIn(research_fellow_draft, response.context['people'])
 
     def test_staff_directory_page_should_not_show_live_speaker(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         speaker_live = PersonPage.objects.get(title='Speaker Live')
-        self.assertNotIn(speaker_live, staff_directory_page.person_pages)
+        self.assertNotIn(speaker_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_speaker(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         speaker_archived = PersonPage.objects.get(title='Speaker Archived')
-        self.assertNotIn(speaker_archived, staff_directory_page.person_pages)
+        self.assertNotIn(speaker_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_speaker(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         speaker_draft = PersonPage.objects.get(title='Speaker Draft')
-        self.assertNotIn(speaker_draft, staff_directory_page.person_pages)
+        self.assertNotIn(speaker_draft, response.context['people'])
 
     def test_staff_directory_page_should_show_live_staff(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         staff_live = PersonPage.objects.get(title='Staff Live')
-        self.assertIn(staff_live, staff_directory_page.person_pages)
+        self.assertIn(staff_live, response.context['people'])
 
     def test_staff_directory_page_should_not_show_archived_staff(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         staff_archived = PersonPage.objects.get(title='Staff Archived')
-        self.assertNotIn(staff_archived, staff_directory_page.person_pages)
+        self.assertNotIn(staff_archived, response.context['people'])
 
     def test_staff_directory_page_should_not_show_draft_staff(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
+        response = self.client.get('/staff/')
         staff_draft = PersonPage.objects.get(title='Staff Draft')
-        self.assertNotIn(staff_draft, staff_directory_page.person_pages)
+        self.assertNotIn(staff_draft, response.context['people'])
 
     def test_staff_directory_page_order_accent_insensitive(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
-        staff_pages = list(staff_directory_page.person_pages)
+        response = self.client.get('/staff/')
+        staff_pages = list(response.context['people'])
         kimi_raikkonen = PersonPage.objects.get(title='Kimi Räikkönen')
         daniel_ricciardo = PersonPage.objects.get(title='Daniel Ricciardo')
         self.assertIn(kimi_raikkonen, staff_pages)
@@ -593,23 +598,15 @@ class PersonListPageTests(WagtailPageTests):
             staff_pages.index(daniel_ricciardo),
         )
 
-    def test_staff_directory_page_should_not_show_board_members(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
-        self.assertEqual(list(staff_directory_page.board_members), [])
-
-    def test_staff_directory_page_should_not_show_senior_management(self):
-        staff_directory_page = PersonListPage.objects.get(title='Staff Directory')
-        self.assertEqual(list(staff_directory_page.senior_management), [])
-
     def test_leadership_page_board_members(self):
-        leadership_page = PersonListPage.objects.get(title='Leadership')
+        response = self.client.get('/leadership/')
         board_member_live = PersonPage.objects.get(title='Board Member Live')
-        self.assertEqual(list(leadership_page.board_members), [board_member_live])
+        self.assertEqual(list(response.context['people']), [board_member_live])
 
     def test_leadership_page_senior_management(self):
-        leadership_page = PersonListPage.objects.get(title='Leadership')
+        response = self.client.get('/leadership/?show=senior-management')
         management_team_live = PersonPage.objects.get(title='Management Team Live')
-        self.assertEqual(list(leadership_page.senior_management), [management_team_live])
+        self.assertEqual(list(response.context['people']), [management_team_live])
 
 
 class PersonPageTests(WagtailPageTests):

--- a/templates/people/person_list_experts_page.html
+++ b/templates/people/person_list_experts_page.html
@@ -12,7 +12,7 @@
   </section>
   <section>
     <div class="container-lg">
-      {% for person in page.person_pages %}
+      {% for person in people %}
         <p>{{ person.title }}</p>
       {% endfor %}
     </div>

--- a/templates/people/person_list_leadership_page.html
+++ b/templates/people/person_list_leadership_page.html
@@ -12,13 +12,8 @@
   </section>
   <section>
     <div class="container-lg">
-      <h2>Board Members</h2>
-      {% for board_member in page.board_members %}
-        <p>{{ board_member.title }}</p>
-      {% endfor %}
-      <h2>Senior Management</h2>
-      {% for manager in page.senior_management %}
-        <p>{{ manager.title }}</p>
+      {% for person in people %}
+        <p>{{ person.title }}</p>
       {% endfor %}
     </div>
   </section>

--- a/templates/people/person_list_staff_page.html
+++ b/templates/people/person_list_staff_page.html
@@ -12,7 +12,7 @@
   </section>
   <section>
     <div class="container-lg">
-      {% for person in page.person_pages %}
+      {% for person in people %}
         <p>{{ person.title }}</p>
       {% endfor %}
     </div>


### PR DESCRIPTION
Queried for person pages in the context rather than in a property. This allows us to check for a `show` query param to display different results on the leadership page.