### PR TITLE
Query table rows for publications page

### DIFF
--- a/templates/publications/publication_list_page.html
+++ b/templates/publications/publication_list_page.html
@@ -2,4 +2,12 @@
 
 {% block content %}
   {% include "includes/hero_standard.html" with title=self.title subtitle=self.subtitle submenu=self.submenu %}
+
+  <ul>
+    {% for publication in publications %}
+      <li>
+        <a href="{{publication.url}}">{{publication.title}}</a>
+      </li>
+    {% endfor %}
+  </ul>
 {% endblock content %}


### PR DESCRIPTION
Initial query for publications table.

Here's my plan for these tables:
1. Query data with pagination (this PR), so that we can start styling the rows.
2. Add topics & types filters, also using query parameters like pages.
3. Update page and filter queries to use Ajax (https://learnwagtail.com/tutorials/wagtail-ajax-templates/). This will require some Javascript to replace the table rows and update the query parameters in the URL without reloading the whole page.