### PR TITLE
Allow BasicPage as child of JobPostingListPage

### DIFF
--- a/careers/models.py
+++ b/careers/models.py
@@ -14,7 +14,7 @@ from wagtail.documents.blocks import DocumentChooserBlock
 class JobPostingListPage(BasicPageAbstract, Page):
     max_count = 1
     parent_page_types = ['core.HomePage']
-    subpage_types = ['careers.JobPostingPage']
+    subpage_types = ['careers.JobPostingPage', 'core.BasicPage']
     templates = 'careers/job_posting_list_page.html'
 
     content_panels = [

--- a/careers/tests.py
+++ b/careers/tests.py
@@ -1,4 +1,4 @@
-from core.models import HomePage
+from core.models import BasicPage, HomePage
 from wagtail.tests.utils import WagtailPageTests
 
 from .models import JobPostingListPage, JobPostingPage
@@ -14,7 +14,7 @@ class JobPostingListPageTests(WagtailPageTests):
     def test_jobpostinglistpage_child_page_types(self):
         self.assertAllowedSubpageTypes(
             JobPostingListPage,
-            {JobPostingPage},
+            {BasicPage, JobPostingPage},
         )
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -438,7 +438,7 @@ class BasicPage(
         SearchablePageAbstract.search_panel,
     ]
 
-    parent_page_types = ['core.BasicPage', 'core.HomePage']
+    parent_page_types = ['careers.JobPostingListPage', 'core.BasicPage', 'core.HomePage']
     subpage_types = [
         'core.AnnualReportListPage',
         'core.BasicPage',

--- a/core/tests.py
+++ b/core/tests.py
@@ -48,7 +48,7 @@ class BasicPageTests(WagtailPageTests):
         """
         self.assertAllowedParentPageTypes(
             BasicPage,
-            {BasicPage, HomePage}
+            {BasicPage, HomePage, JobPostingListPage}
         )
 
     def test_basicpage_child_page_types(self):


### PR DESCRIPTION
#### Description of changes
Initial part for CIGIHub/cigi-tickets#231

The "Why CIGI?" and "Why Waterloo?" pages exist at `/careers/why-cigi` and `/careers/why-waterloo`, respectively. This PR simply allows those pages to be created as children of the Careers page, which is an instance of `JobPostingListPage`.