### PR TITLE
Update build script to default npm build

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Run migrations
       run: python manage.py migrate
     - name: Build webpack
-      run: npm run build:prod
+      run: npm build
       env:
         FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
     - name: Collect static files

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Run migrations
       run: python manage.py migrate
     - name: Build webpack
-      run: npm build
+      run: npm run-script build
       env:
         FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
     - name: Collect static files

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": "^12"
   },
   "scripts": {
-    "build:prod": "rimraf static/bundles && cross-env NODE_ENV=production webpack --mode production --progress",
+    "build": "rimraf static/bundles && cross-env NODE_ENV=production webpack --mode production --progress",
     "lint:js": "eslint . --ext .js",
     "lint:sass": "sass-lint -c .sass-lint.yml 'cigionline/static/css/**/*.scss' -v -q --max-warnings 0",
     "start": "cross-env NODE_ENV=development webpack --mode development --progress --watch"


### PR DESCRIPTION
#### Description of changes
Updating the build script from `npm run build:prod` to `npm build`. When deploying on Heroku, the node buildpack will run `npm build` during its setup. The idea here is to add the node buildpack before the Django buildpack so the webpack assets are built before Django is deployed.