### PR TITLE
Remove margins from sections

### DIFF
--- a/cigionline/static/css/includes/_hero_article.scss
+++ b/cigionline/static/css/includes/_hero_article.scss
@@ -1,12 +1,13 @@
 section {
   &.article-hero {
     @include breakpoint($medium) {
-      padding-top: 3em;
+      padding-top: 6em;
     }
 
     background-color: transparent;
     color: $black;
     display: block;
+    padding-top: 3em;
     text-align: center;
 
     h1 {

--- a/cigionline/static/css/includes/_hero_publication.scss
+++ b/cigionline/static/css/includes/_hero_publication.scss
@@ -1,12 +1,13 @@
 section {
   &.publication-hero {
     @include breakpoint($medium) {
-      padding-top: 3em;
+      padding-top: 6em;
     }
 
     background-color: transparent;
     color: $black;
     display: block;
+    padding-top: 3em;
     text-align: center;
 
     h1 {

--- a/cigionline/static/css/layout/_sections.scss
+++ b/cigionline/static/css/layout/_sections.scss
@@ -1,11 +1,6 @@
 section {
-  @include media-breakpoint-up(md) {
-    margin: 3em 0;
-  }
-  margin: 1em 0;
-
   &.hero {
-    margin-top: 0;
+    margin-bottom: 3em;
   }
 
   &.main {


### PR DESCRIPTION
#### Description of changes
The content pages are starting to look too spaced out in some instances because of the margin added to `<section>` tags. Removed the global margin and added it to the few places where we need it.