### PR TITLE
Fix script execution and clean up empty script tags

### DIFF
--- a/templates/articles/article_landing_page.html
+++ b/templates/articles/article_landing_page.html
@@ -5,7 +5,7 @@
   {% render_bundle 'articleLandingPage' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'articleLandingPage' 'js' attrs='async' %}
+  {% render_bundle 'articleLandingPage' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -4,9 +4,6 @@
 {% block extra_css %}
   {% render_bundle 'articlePage' 'css' %}
 {% endblock %}
-{% block extra_js %}
-  {% render_bundle 'articlePage' 'js' attrs='async' %}
-{% endblock %}
 
 {% block content %}
   {% include "includes/hero_article.html" with title=self.title subtitle=self.subtitle %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,7 @@
     {% block extra_css %}
       {# Override this in templates to add extra CSS #}
     {% endblock %}
-    {% render_bundle 'cigionline' 'js' attrs='async' %}
+    {% render_bundle 'cigionline' 'js' attrs='defer' %}
     {% block extra_js %}
       {# Override this in templates to add extra JS #}
     {% endblock %}

--- a/templates/events/event_list_page.html
+++ b/templates/events/event_list_page.html
@@ -5,7 +5,7 @@
   {% render_bundle 'eventListPage' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'eventListPage' 'js' attrs='async' %}
+  {% render_bundle 'eventListPage' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/events/event_page.html
+++ b/templates/events/event_page.html
@@ -4,9 +4,6 @@
 {% block extra_css %}
   {% render_bundle 'eventPage' 'css' %}
 {% endblock %}
-{% block extra_js %}
-  {% render_bundle 'eventPage' 'js' attrs='async' %}
-{% endblock %}
 
 {% block content %}
   {% include "includes/hero_standard.html" with title=self.title %}

--- a/templates/multimedia/multimedia_list_page.html
+++ b/templates/multimedia/multimedia_list_page.html
@@ -6,7 +6,7 @@
   {% render_bundle 'multimediaListPage' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'multimediaListPage' 'js' attrs='async' %}
+  {% render_bundle 'multimediaListPage' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/multimedia/multimedia_page.html
+++ b/templates/multimedia/multimedia_page.html
@@ -5,7 +5,7 @@
   {% render_bundle 'multimediaPage' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'multimediaPage' 'js' attrs='async' %}
+  {% render_bundle 'multimediaPage' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/publications/publication_list_page.html
+++ b/templates/publications/publication_list_page.html
@@ -5,7 +5,7 @@
   {% render_bundle 'publicationListPage' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'publicationListPage' 'js' attrs='async' %}
+  {% render_bundle 'publicationListPage' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block content %}

--- a/templates/publications/publication_page.html
+++ b/templates/publications/publication_page.html
@@ -4,9 +4,6 @@
 {% block extra_css %}
   {% render_bundle 'publicationPage' 'css' %}
 {% endblock %}
-{% block extra_js %}
-  {% render_bundle 'publicationPage' 'js' attrs='async' %}
-{% endblock %}
 
 {% block content %}
   {% include "includes/hero_publication.html" with title=self.title subtitle=self.subtitle download=self.pdf_downloads %}

--- a/templates/themes/ai_series/article_page.html
+++ b/templates/themes/ai_series/article_page.html
@@ -5,9 +5,6 @@
   {% render_bundle 'articlePage' 'css' %}
   {% render_bundle 'themeAISeries' 'css' %}
 {% endblock %}
-{% block extra_js %}
-  {% render_bundle 'articlePage' 'js' attrs='async' %}
-{% endblock %}
 
 {% block body_class %}ai-series-article{% endblock %}
 

--- a/templates/themes/ai_series/multimedia_page.html
+++ b/templates/themes/ai_series/multimedia_page.html
@@ -6,7 +6,7 @@
   {% render_bundle 'themeAISeries' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'multimediaPage' 'js' attrs='async' %}
+  {% render_bundle 'multimediaPage' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block body_class %}ai-series-multimedia{% endblock %}

--- a/templates/themes/big_tech_s3/article_page.html
+++ b/templates/themes/big_tech_s3/article_page.html
@@ -9,7 +9,7 @@
   {% render_bundle 'themeBigTechS3' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'themeBigTechS3' 'js' attrs='async' %}
+  {% render_bundle 'themeBigTechS3' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block body_class %}big-tech-s3-theme big-tech-s3-article{% endblock %}

--- a/templates/themes/big_tech_s3/multimedia_page.html
+++ b/templates/themes/big_tech_s3/multimedia_page.html
@@ -9,7 +9,7 @@
   {% render_bundle 'themeBigTechS3' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'themeBigTechS3' 'js' attrs='async' %}
+  {% render_bundle 'themeBigTechS3' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block body_class %}big-tech-s3-theme big-tech-s3-multimedia{% endblock %}

--- a/templates/themes/data_series/article_page.html
+++ b/templates/themes/data_series/article_page.html
@@ -5,9 +5,6 @@
   {% render_bundle 'articlePage' 'css' %}
   {% render_bundle 'themeDataSeries' 'css' %}
 {% endblock %}
-{% block extra_js %}
-  {% render_bundle 'articlePage' 'js' attrs='async' %}
-{% endblock %}
 
 {% block body_class %}data-series-article{% endblock %}
 

--- a/templates/themes/data_series/multimedia_page.html
+++ b/templates/themes/data_series/multimedia_page.html
@@ -6,7 +6,7 @@
   {% render_bundle 'themeDataSeries' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'multimediaPage' 'js' attrs='async defer' %}
+  {% render_bundle 'multimediaPage' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block body_class %}data-series-multimedia{% endblock %}

--- a/templates/themes/innovation_series/article_page.html
+++ b/templates/themes/innovation_series/article_page.html
@@ -5,10 +5,6 @@
   {% render_bundle 'articlePage' 'css' %}
   {% render_bundle 'themeInnovationSeries' 'css' %}
 {% endblock %}
-{% block extra_js %}
-  {% render_bundle 'articlePage' 'js' attrs='async' %}
-  {% render_bundle 'themeInnovationSeries' 'js' attrs='async' %}
-{% endblock %}
 
 {% block body_class %}innovation-series-article{% endblock %}
 

--- a/templates/themes/innovation_series/multimedia_page.html
+++ b/templates/themes/innovation_series/multimedia_page.html
@@ -6,8 +6,7 @@
   {% render_bundle 'themeInnovationSeries' 'css' %}
 {% endblock %}
 {% block extra_js %}
-  {% render_bundle 'multimediaPage' 'js' attrs='async' %}
-  {% render_bundle 'themeInnovationSeries' 'js' attrs='async' %}
+  {% render_bundle 'multimediaPage' 'js' attrs='defer' %}
 {% endblock %}
 
 {% block body_class %}innovation-series-multimedia{% endblock %}

--- a/templates/themes/longform/article_page.html
+++ b/templates/themes/longform/article_page.html
@@ -4,9 +4,6 @@
 {% block extra_css %}
   {% render_bundle 'themeLongform' 'css' %}
 {% endblock %}
-{% block extra_js %}
-  {% render_bundle 'themeLongform' 'js' attrs='async' %}
-{% endblock %}
 
 {% block body_class %}longform-article{% endblock %}
 


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#323

Updated the scripts to use defer rather than async, so that they get executed after the DOM is fully parsed. Also removed some scripts, since some webpack bundles only contain CSS (such as `articlePage`).
