### PR TITLE
Style body section for Longform article series page

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = BLK100, E501
+ignore = BLK100, E501, W504
 exclude =
     .git,
     __pycache__,

--- a/cigionline/static/themes/longform/css/_longform_article_series.scss
+++ b/cigionline/static/themes/longform/css/_longform_article_series.scss
@@ -1,6 +1,22 @@
 @import '../../../css/global/animations/bounce';
 
 .longform-article-series {
+  .body {
+    background-color: $longform-series-body-color;
+    padding-bottom: 0.5em;
+    padding-top: 1.5em;
+
+    .about-series {
+      font-size: 1.5em;
+      font-weight: 500;
+      margin-bottom: 1em;
+
+      span {
+        border-bottom: 5px solid $black;
+      }
+    }
+  }
+
   .longform-article-series-hero {
     background-position-x: 50%;
     background-position-y: 50%;

--- a/cigionline/static/themes/longform/css/longform.scss
+++ b/cigionline/static/themes/longform/css/longform.scss
@@ -3,6 +3,7 @@
 
 $longform-background-color: #f2f0ea;
 $longform-hero-background-color: #f2f0ea;
+$longform-series-body-color: #ebe9e5;
 
 @import './longform_article_series';
 @import './longform_article';

--- a/streams/blocks.py
+++ b/streams/blocks.py
@@ -12,10 +12,20 @@ class ThemeableBlock:
     def get_theme_dir(self, theme_name):
         return theme_name.lower().replace(' ', '_').replace("-", '_')
 
+    def get_page_type_dir(self, verbose_name):
+        return verbose_name.lower().replace(' ', '_')
+
     def get_theme_template(self, standard_template, context, template_name):
-        if context and context['page'] and hasattr(context['page'], 'theme') and \
-                context['page'].theme and self.get_theme_dir(context['page'].theme.name) in self.implemented_themes:
-            return f'themes/{self.get_theme_dir(context["page"].theme.name)}/streams/{template_name}.html'
+        if (
+            context and
+            context['page'] and
+            hasattr(context['page'], '_meta') and
+            hasattr(context['page']._meta, 'verbose_name') and
+            hasattr(context['page'], 'theme') and
+            context['page'].theme and
+            f'{self.get_theme_dir(context["page"].theme.name)}_{self.get_page_type_dir(context["page"]._meta.verbose_name)}' in self.implemented_themes
+        ):
+            return f'themes/{self.get_theme_dir(context["page"].theme.name)}/streams/{self.get_page_type_dir(context["page"]._meta.verbose_name)}_{template_name}.html'
         return standard_template
 
 
@@ -254,6 +264,10 @@ class ParagraphBlock(blocks.RichTextBlock, ThemeableBlock):
             'superscript',
             'ul',
         ]
+
+    implemented_themes = [
+        'longform_opinion_series',
+    ]
 
     def get_template(self, context, *args, **kwargs):
         standard_template = super(ParagraphBlock, self).get_template(context, *args, **kwargs)

--- a/templates/themes/longform/article_series_page.html
+++ b/templates/themes/longform/article_series_page.html
@@ -49,7 +49,7 @@
 {% block content %}
   <section class="body" id="article-body">
     <div class="container-lg">
-      <h2>About the Series</h2>
+      <h2 class="about-series"><span>About the Series</span></h2>
     </div>
     {% for block in self.body %}
       {% include_block block %}

--- a/templates/themes/longform/streams/opinion_series_paragraph_block.html
+++ b/templates/themes/longform/streams/opinion_series_paragraph_block.html
@@ -1,0 +1,3 @@
+<div class="container-lg">
+  {{ self }}
+</div>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#334

This includes the first implementation of a themed StreamField block. I expanded the condition to check for both theme and page type, since in this case I needed the paragraphs in the article series page to be in the large container but the regular article page to be in the small container.

![Screen Shot 2021-01-08 at 10 29 36 AM](https://user-images.githubusercontent.com/10100465/104033001-f3163900-519c-11eb-8cda-9970d558cc74.png)
![Screen Shot 2021-01-08 at 10 29 47 AM](https://user-images.githubusercontent.com/10100465/104033012-f6a9c000-519c-11eb-9087-27598faa18a1.png)

