### PR TITLE
cigi-318 - revisit and clean up h3 styling

### DIFF
--- a/cigionline/static/themes/data_series/css/_article_page.scss
+++ b/cigionline/static/themes/data_series/css/_article_page.scss
@@ -150,9 +150,10 @@
 
   h3 {
     font-family: 'din-condensed', sans-serif;
-    font-size: 1.225em;
+    font-size: 1.3em;
     font-weight: 400;
-    margin-bottom: .4285em;
+    line-height: 1.45em;
+    margin-bottom: .485em;
     margin-top: 1em;
   }
 
@@ -186,10 +187,6 @@
   }
 
   .text-border-block {
-    h3 {
-      margin-bottom: .5em;
-      margin-top: 1em;
-    }
 
     .block-contents {
       border: solid 1px $data-series-primary-color;


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#318
tweaking and cleaning up h3 styling
Tested on staging of live server, there doesn't appear to be styling for h2 or h4 for the data series.
