### PR TITLE
Create experts section for home page

### DIFF
--- a/cigionline/static/css/cigionline.scss
+++ b/cigionline/static/css/cigionline.scss
@@ -39,6 +39,7 @@ $fa-font-path: '../fontawesome-pro/webfonts';
 @import 'includes/features/feature_content_medium';
 @import 'includes/features/feature_content_small';
 @import 'includes/features/feature_publication_teaser';
+@import 'includes/features/feature_expert_short';
 
 @import 'streams/accordion_block';
 @import 'streams/autoplay_video_block';

--- a/cigionline/static/css/includes/features/_feature_expert_short.scss
+++ b/cigionline/static/css/includes/features/_feature_expert_short.scss
@@ -1,0 +1,29 @@
+article {
+  &.feature-expert-short {
+    .feature-expert-person-details {
+      align-items: center;
+      display: flex;
+
+      img {
+        border-radius: 50%;
+        height: 70px;
+        margin-right: 10px;
+        width: 70px;
+      }
+
+      .feature-expert-person-title {
+        h3 {
+          @include link($color: $black, $hover-color: $cigi-primary-colour);
+          font-size: 1.0625em;
+          margin-bottom: 0;
+        }
+
+        p {
+          color: $cigi-text-grey;
+          font-size: 0.9em;
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+}

--- a/cigionline/static/css/layout/_home.scss
+++ b/cigionline/static/css/layout/_home.scss
@@ -7,16 +7,45 @@
     padding-top: 5em;
   }
 
+  .homepage-featured-experts,
+  .homepage-featured-multimedia,
+  .homepage-featured-publications {
+    margin-bottom: 4em;
+  }
+
+  .homepage-featured-experts {
+    .homepage-featured-expert-row {
+      &:last-child {
+        article {
+          border-bottom: 0;
+          border-right: 0;
+        }
+      }
+
+      article {
+        @include media-breakpoint-up(md) {
+          border-bottom: 0;
+          border-right: 1px solid $cigi-light-grey;
+          margin-bottom: 0;
+          padding-bottom: 0;
+          padding-right: 1em;
+        }
+        border-bottom: 1px solid $cigi-light-grey;
+        border-right: 0;
+        margin-bottom: 1.5em;
+        padding-bottom: 1.5em;
+        padding-right: 0;
+      }
+    }
+  }
+
   .homepage-featured-multimedia {
     background-color: $black;
-    margin-bottom: 4em;
     padding-bottom: 4em;
     padding-top: 4em;
   }
 
   .homepage-featured-publications {
-    margin-bottom: 4em;
-
     .homepage-featured-publication-row {
       &:last-child {
         article {

--- a/home/models.py
+++ b/home/models.py
@@ -98,6 +98,12 @@ class HomePage(Page):
             featured_multimedia_small.append(item.featured_multimedia)
         return featured_multimedia_small
 
+    def featured_experts_list(self):
+        featured_experts = []
+        for item in self.featured_experts.all()[:3]:
+            featured_experts.append(item.featured_expert)
+        return featured_experts
+
     max_count = 1
     subpage_types = [
         'articles.ArticleLandingPage',

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -43,7 +43,11 @@
     <div class="container">
       <div class="row">
         <div class="col-12">
-          <h2 class="homepage-subheading"><a href="/publications/">Publications</a></h2>
+          <h2 class="homepage-subheading">
+            <a href="/publications/">
+              Publications
+            </a>
+          </h2>
         </div>
       </div>
       <div class="row">
@@ -59,7 +63,11 @@
     <div class="container">
       <div class="row">
         <div class="col-12">
-          <h2 class="homepage-subheading dark-mode"><a href="/multimedia/">Multimedia</a></h2>
+          <h2 class="homepage-subheading dark-mode">
+            <a href="/multimedia/">
+              Multimedia
+            </a>
+          </h2>
         </div>
       </div>
       <div class="row">
@@ -77,6 +85,26 @@
             {% include "includes/features/feature_content_small.html" with content=item dark_mode=True %}
           {% endfor %}
         </div>
+      </div>
+    </div>
+  </section>
+  <section class="homepage-featured-experts">
+    <div class="container">
+      <div class="row">
+        <div class="col-12">
+          <h2 class="homepage-subheading">
+            <a href="/experts/">
+              Experts
+            </a>
+          </h2>
+        </div>
+      </div>
+      <div class="row">
+        {% for expert in self.featured_experts_list %}
+          <div class="col-12 col-md-4 homepage-featured-expert-row">
+            {% include "includes/features/feature_expert_short.html" with expert=expert %}
+          </div>
+        {% endfor %}
       </div>
     </div>
   </section>

--- a/templates/includes/features/feature_expert_short.html
+++ b/templates/includes/features/feature_expert_short.html
@@ -1,0 +1,19 @@
+{% load wagtailimages_tags %}
+<article class="feature-expert-short">
+
+  <div class="feature-expert-person-details">
+    <a href="{{ expert.url }}">
+      {% image expert.image_square fill-140x140 %}
+    </a>
+    <div class="feature-expert-person-title">
+      <h3>
+        <a href="{{ expert.url }}">
+          {{ expert.title }}
+        </a>
+      </h3>
+      <p>
+        {{ expert.position }}
+      </p>
+    </div>
+  </div>
+</article>


### PR DESCRIPTION
#### Description of changes
Part of CIGIHub/cigi-tickets#411

This is just the initial step, adding the section and creating a featured expert include. I realized I can't yet query for Latest Activity - as the authors are added in StreamFields. I'm going to change this to have authors be another table that can be queried on.

Full:
![Screenshot from 2021-01-17 21-46-26](https://user-images.githubusercontent.com/10100465/104867071-039d8080-590e-11eb-821e-fb350310d982.png)

Mobile:
![Screenshot from 2021-01-17 21-46-31](https://user-images.githubusercontent.com/10100465/104867079-06987100-590e-11eb-8d49-25407d538c4d.png)
