### PR TITLE
Add latest activity to experts section on home page

### DIFF
--- a/cigionline/static/css/includes/features/_feature_expert_short.scss
+++ b/cigionline/static/css/includes/features/_feature_expert_short.scss
@@ -1,5 +1,25 @@
 article {
   &.feature-expert-short {
+    .feature-expert-latest-activity {
+      h4 {
+        color: $cigi-text-grey;
+        font-family: 0.75em;
+        margin-top: 1.3em;
+        text-transform: uppercase;
+      }
+
+      h5 {
+        @include link($color: $black, $hover-color: $cigi-primary-colour);
+        font-size: 1.0625em;
+        font-weight: 400;
+        line-height: 1.4;
+      }
+
+      .authors {
+        margin: 0;
+      }
+    }
+
     .feature-expert-person-details {
       align-items: center;
       display: flex;

--- a/templates/includes/features/feature_content_large.html
+++ b/templates/includes/features/feature_content_large.html
@@ -25,7 +25,7 @@
     {% include 'includes/topics.html' with topics=content.topics %}
     {% include 'includes/features/feature_content_title.html' %}
     {% include 'includes/features/feature_content_subtitle.html' %}
-    {% include 'includes/features/feature_content_people.html' %}
+    {% include 'includes/features/feature_content_people.html' with authors=content.authors.all %}
     <div class="feature-content-date meta">{{ content.publishing_date|date:"F j, Y" }}</div>
   </div>
 </article>

--- a/templates/includes/features/feature_content_medium.html
+++ b/templates/includes/features/feature_content_medium.html
@@ -24,7 +24,7 @@
   <div class="feature-content-text center-text">
     {% include 'includes/topics.html' with topics=content.topics %}
     {% include 'includes/features/feature_content_title.html' %}
-    {% include 'includes/features/feature_content_people.html' %}
+    {% include 'includes/features/feature_content_people.html' with authors=content.authors.all %}
     <div class="feature-content-date meta">{{ content.publishing_date|date:"F j, Y" }}</div>
   </div>
 </article>

--- a/templates/includes/features/feature_content_people.html
+++ b/templates/includes/features/feature_content_people.html
@@ -1,6 +1,6 @@
 <ul class="custom-text-list feature-content-people-list">
   {% with 3 as people_limit %}
-    {% for item in content.authors.all %}
+    {% for item in authors %}
       {% if forloop.counter <= people_limit %}
         <li>
           <a href="{{ item.author.url }}">

--- a/templates/includes/features/feature_content_small.html
+++ b/templates/includes/features/feature_content_small.html
@@ -4,7 +4,7 @@
   <div class="feature-content-text center-text">
     {% include 'includes/topics.html' with topics=content.topics %}
     {% include 'includes/features/feature_content_title.html' %}
-    {% include 'includes/features/feature_content_people.html' %}
+    {% include 'includes/features/feature_content_people.html' with authors=content.authors.all %}
     <div class="feature-content-date meta">{{ content.publishing_date|date:"F j, Y" }}</div>
   </div>
 </article>

--- a/templates/includes/features/feature_expert_short.html
+++ b/templates/includes/features/feature_expert_short.html
@@ -1,5 +1,5 @@
 {% load wagtailimages_tags %}
-<article class="feature-expert-short">
+<article class="feature-content feature-expert-short">
 
   <div class="feature-expert-person-details">
     <a href="{{ expert.url }}">
@@ -17,6 +17,11 @@
     </div>
   </div>
   {% if expert.latest_activity %}
-    <h4>{{ expert.latest_activity.title }}
+    <div class="feature-expert-latest-activity">
+      <h4>Latest Activity</h4>
+      {% include "includes/topics.html" with topics=expert.latest_activity.topics %}
+      <h5><a href="{{ expert.latest_activity.url }}">{{ expert.latest_activity.title }}</a></h5>
+      {% include "includes/features/feature_content_people.html" with authors=expert.latest_activity.authors.all %}
+    </div>
   {% endif %}
 </article>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#411

Building on the experts section that was added in #790, this adds the latest activity section now that we can query content pages from the expert as a result of #797.

Full:
![Screenshot from 2021-01-19 10-41-07](https://user-images.githubusercontent.com/10100465/105057877-a99ed700-5a43-11eb-9644-89bfa02a9d8a.png)

Mobile:
![Screenshot from 2021-01-19 10-41-12](https://user-images.githubusercontent.com/10100465/105057891-ac013100-5a43-11eb-9887-7312a7271e7b.png)
