### PR TITLE
Add Issuu oEmbed to publication page

### DIFF
--- a/templates/publications/publication_page.html
+++ b/templates/publications/publication_page.html
@@ -14,6 +14,18 @@
 
   {% include "includes/body.html" with body=self.body %}
 
+  {% if self.embed_issuu %}
+    <section>
+      <div class="container">
+        <div class="row">
+          <div class="col-12">
+            {% embed self.embed_issuu max_width=1110 %}
+          </div>
+        </div>
+      </div>
+    </section>
+  {% endif %}
+
   {% if self.has_book_metadata %}
     <div class="container">
       <div class="row justify-content-center">


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#424

Added as a full container since the Issuu only supports double page embeds through oEmbed.

<img width="1443" alt="Screen Shot 2021-01-21 at 12 32 50 AM" src="https://user-images.githubusercontent.com/10100465/105284499-96ddec80-5b80-11eb-89cd-495d4b82095a.png">

