### PR TITLE
Fix search table crashing after a no results query

### DIFF
--- a/cigionline/static/js/components/SearchTable.js
+++ b/cigionline/static/js/components/SearchTable.js
@@ -369,7 +369,9 @@ class SearchTable extends React.Component {
                   </table>
                 )
             ) : (
-              <p>Your query returned no results. Please check your spelling and try again.</p>
+              <p ref={this.searchResultsRef}>
+                Your query returned no results. Please check your spelling and try again.
+              </p>
             )}
         <Paginator
           currentPage={currentPage}


### PR DESCRIPTION
React component crashes when trying to initiate another search after a search that returned no results, when the window attempts to scroll to the ref that wasn't added to the no results paragraph.