### PR TITLE
Remove extra spaces around editors names on publication hero

### DIFF
--- a/cigionline/static/css/includes/_hero_publication_book.scss
+++ b/cigionline/static/css/includes/_hero_publication_book.scss
@@ -24,6 +24,7 @@ section {
 
     .label {
       padding-right: 0.2em;
+      white-space: nowrap;
     }
 
     .authors {

--- a/templates/includes/editors.html
+++ b/templates/includes/editors.html
@@ -1,8 +1,6 @@
 <div class="custom-text-list authors">
   {% for item in editors %}
-    <a class="block-author" href="{{ item.editor.url }}">
-      {{ item.editor.title }}
-    </a>
+    <a class="block-author" href="{{ item.editor.url }}">{{ item.editor.title }}</a>
   {% endfor %}
   {% for item in external_editors %}
     {% if item.block_type == 'external_person' %}


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#490
