### PR TITLE
Hide issuu embed on mobile

### DIFF
--- a/cigionline/static/pages/publication_page/css/publication_page.scss
+++ b/cigionline/static/pages/publication_page/css/publication_page.scss
@@ -17,7 +17,7 @@
 
 .publication-book-trailer {
   .publication-book-trailer-embed {
-    margin-top: .5em;
+    margin-top: 0.5em;
 
     iframe {
       width: 100%;
@@ -38,5 +38,17 @@
   p {
     color: $cigi-text-grey;
     margin: 0;
+  }
+}
+
+.embed-issuu {
+  @include media-breakpoint-up(sm) {
+    display: block;
+  }
+  display: none;
+
+  .col {
+    display: flex;
+    justify-content: center;
   }
 }

--- a/templates/publications/publication_page.html
+++ b/templates/publications/publication_page.html
@@ -18,10 +18,10 @@
   {% include "includes/body.html" with body=self.body %}
 
   {% if self.embed_issuu %}
-    <section>
+    <section class="embed-issuu">
       <div class="container">
         <div class="row">
-          <div class="col-12">
+          <div class="col">
             {% embed self.embed_issuu max_width=1110 %}
           </div>
         </div>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#499

- Hide issuu embed for screens < 567px

Test: http://127.0.0.1:8000/publications/managed-retreat-high-risk-flood-areas-design-considerations-effective-property-buyout/

![image](https://user-images.githubusercontent.com/40705848/109542668-5cc30d00-7a93-11eb-86f6-57583ba00907.png)

