### PR TITLE
CIGI-520: Limit article landing page slider to 10 items

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -74,7 +74,7 @@ class ArticleLandingPage(Page):
     def all_article_series(self):
         return ArticleSeriesPage.objects.prefetch_related(
             'topics',
-        ).live().public().order_by('-publishing_date')
+        ).live().public().order_by('-publishing_date')[:10]
 
     content_panels = Page.content_panels + [
         MultiFieldPanel(


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#520

![image](https://user-images.githubusercontent.com/40705848/109902283-3dc9a400-7c68-11eb-9533-328a11e5a567.png)
