### PR TITLE
CIGI-524: Adjust search input text focus and background color

### DIFF
--- a/cigionline/static/css/global/_global.scss
+++ b/cigionline/static/css/global/_global.scss
@@ -93,6 +93,10 @@ img {
       border: 0;
       height: 100%;
       padding: 0;
+
+      &:focus {
+        box-shadow: none;
+      }
     }
 
     .input-group-append {

--- a/cigionline/static/css/includes/_top_bar.scss
+++ b/cigionline/static/css/includes/_top_bar.scss
@@ -305,22 +305,33 @@ header {
 
       .input-group-search {
         border-bottom: 3px solid $white;
-        height: calc(1.9em + 0.25em);
+        height: 2.5em;
 
         .form-control {
+          background-color: $black;
           color: $white;
           font-size: 1.8em;
           height: 100%;
+          margin-right: 1em;
 
           &::-webkit-input-placeholder,
           &::placeholder {
             color: $white;
           }
+
+          &:-webkit-autofill {
+            -webkit-box-shadow: 0 0 0 1000px $black inset;
+            -webkit-text-fill-color: $white;
+          }
         }
 
-        .btn-search {
-          font-size: 1.0625em;
-          height: 100%;
+        .input-group-append {
+          margin-left: 0.25em;
+
+          .btn-search {
+            font-size: 1.0625em;
+            height: 100%;
+          }
         }
       }
     }


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#524

- Remove focus box shadow from search input
- Change dropdown search input background to black

![image](https://user-images.githubusercontent.com/40705848/110017634-6c8d5c00-7cf4-11eb-959f-68ff021206cc.png)
![image](https://user-images.githubusercontent.com/40705848/110017685-7c0ca500-7cf4-11eb-92c4-a44e096f3ffd.png)

