### PR TITLE
CIGI-404: Move bootstrap css to global scss file

### DIFF
--- a/cigionline/static/css/cigionline.scss
+++ b/cigionline/static/css/cigionline.scss
@@ -1,5 +1,7 @@
 $fa-font-path: '../fontawesome-pro/webfonts';
 @import '~@fortawesome/fontawesome-pro/css/all.css';
+@import 'global/bootstrap_variables_overwrite';
+@import '~bootstrap/scss/bootstrap';
 
 @import 'global/resets';
 @import 'global/mixins';

--- a/cigionline/static/css/global/_mixins.scss
+++ b/cigionline/static/css/global/_mixins.scss
@@ -1,7 +1,6 @@
-@import './bootstrap_variables_overwrite';
-
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
 @import '~bootstrap/scss/mixins';
-@import '~bootstrap/scss/bootstrap';
 
 @import './variables';
 


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#404

- Moved bootstrap import to main scss file
![image](https://user-images.githubusercontent.com/40705848/112867845-61c2ae80-9089-11eb-9d3d-6a48ec4256f2.png)

