### PR TITLE
CIGI-558: Fix ContentType null pointer error on admin search

### DIFF
--- a/annual_reports/models.py
+++ b/annual_reports/models.py
@@ -49,6 +49,7 @@ class AnnualReportListPage(BasicPageAbstract, Page):
     settings_panels = Page.settings_panels + [
         BasicPageAbstract.submenu_panel,
     ]
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
 
     class Meta:
         verbose_name = 'Annual Report List Page'

--- a/articles/models.py
+++ b/articles/models.py
@@ -97,6 +97,8 @@ class ArticleLandingPage(BasicPageAbstract, Page):
         )
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     class Meta:
         verbose_name = 'Article Landing Page'
 
@@ -136,6 +138,8 @@ class MediaLandingPage(BasicPageAbstract, Page):
     settings_panels = Page.settings_panels + [
         BasicPageAbstract.submenu_panel,
     ]
+
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
 
     max_count = 1
     parent_page_types = ['home.HomePage']
@@ -444,8 +448,7 @@ class ArticlePage(
         ThemeablePageAbstract.theme_panel,
     ]
 
-    search_fields = Page.search_fields \
-        + BasicPageAbstract.search_fields \
+    search_fields = BasicPageAbstract.search_fields \
         + ContentPage.search_fields \
         + [
             index.FilterField('article_type'),
@@ -487,6 +490,8 @@ class ArticleTypePage(BasicPageAbstract, Page):
     settings_panels = Page.settings_panels + [
         BasicPageAbstract.submenu_panel,
     ]
+
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
 
     parent_page_types = ['articles.ArticleListPage']
     subpage_types = []

--- a/careers/models.py
+++ b/careers/models.py
@@ -32,6 +32,8 @@ class JobPostingListPage(BasicPageAbstract, Page):
         BasicPageAbstract.submenu_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     class Meta:
         verbose_name = 'Careers Page'
 

--- a/core/models.py
+++ b/core/models.py
@@ -437,7 +437,7 @@ class ContentPage(Page, SearchablePageAbstract):
         FieldPanel('topics'),
     ]
 
-    search_fields = [
+    search_fields = Page.search_fields + [
         index.FilterField('author_ids'),
         index.SearchField('author_names'),
         index.FilterField('contenttype'),
@@ -563,6 +563,8 @@ class BasicPage(
         SearchablePageAbstract.search_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     parent_page_types = ['careers.JobPostingListPage', 'core.BasicPage', 'home.HomePage']
     subpage_types = [
         'annual_reports.AnnualReportListPage',
@@ -598,6 +600,8 @@ class FundingPage(BasicPageAbstract, Page):
         BasicPageAbstract.submenu_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     class Meta:
         verbose_name = 'Funding Page'
 
@@ -610,6 +614,8 @@ class PrivacyNoticePage(
         BasicPageAbstract.title_panel,
         BasicPageAbstract.body_panel,
     ]
+
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
 
     max_count = 1
     parent_page_types = ['home.HomePage']

--- a/events/models.py
+++ b/events/models.py
@@ -49,6 +49,8 @@ class EventListPage(BasicPageAbstract, Page):
         BasicPageAbstract.submenu_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     def featured_events_list(self):
         featured_events = []
         for item in self.featured_events.all()[:6]:
@@ -242,8 +244,7 @@ class EventPage(
         SearchablePageAbstract.search_panel,
     ]
 
-    search_fields = Page.search_fields \
-        + BasicPageAbstract.search_fields \
+    search_fields = BasicPageAbstract.search_fields \
         + ContentPage.search_fields \
         + [
             index.FilterField('publishing_date'),

--- a/multimedia/models.py
+++ b/multimedia/models.py
@@ -68,6 +68,8 @@ class MultimediaListPage(BasicPageAbstract, Page):
         BasicPageAbstract.submenu_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     def featured_large(self):
         return self.featured_multimedia.all()[0:1]
 
@@ -323,8 +325,7 @@ class MultimediaPage(
         ThemeablePageAbstract.theme_panel,
     ]
 
-    search_fields = Page.search_fields \
-        + BasicPageAbstract.search_fields \
+    search_fields = BasicPageAbstract.search_fields \
         + ContentPage.search_fields \
         + [
             index.FilterField('multimedia_series'),

--- a/newsletters/models.py
+++ b/newsletters/models.py
@@ -25,6 +25,8 @@ class NewsletterListPage(BasicPageAbstract, Page):
         BasicPageAbstract.submenu_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     class Meta:
         verbose_name = 'Newsletter List Page'
 

--- a/people/models.py
+++ b/people/models.py
@@ -77,6 +77,8 @@ class PersonListPage(BasicPageAbstract, Page):
         BasicPageAbstract.submenu_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     def featured_experts_random(self):
         expert_id_list = list(PersonPage.objects.live().public().filter(person_types=4, archive=0).values_list('id', flat=True))
         random_expert_id_list = random.sample(expert_id_list, min(len(expert_id_list), 6))

--- a/publications/models.py
+++ b/publications/models.py
@@ -68,6 +68,8 @@ class PublicationListPage(BasicPageAbstract, Page):
         BasicPageAbstract.submenu_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     class Meta:
         verbose_name = 'Publication List Page'
 
@@ -354,8 +356,7 @@ class PublicationPage(
         SearchablePageAbstract.search_panel,
     ]
 
-    search_fields = Page.search_fields \
-        + BasicPageAbstract.search_fields \
+    search_fields = BasicPageAbstract.search_fields \
         + ContentPage.search_fields \
         + [
             index.FilterField('publication_series'),
@@ -384,6 +385,8 @@ class PublicationTypePage(BasicPageAbstract, Page):
         BasicPageAbstract.submenu_panel,
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     parent_page_types = ['publications.PublicationListPage']
     subpage_types = []
     templates = 'publications/publication_type_page.html'
@@ -407,6 +410,8 @@ class PublicationSeriesListPage(BasicPageAbstract, Page):
     settings_panels = Page.settings_panels + [
         BasicPageAbstract.submenu_panel,
     ]
+
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
 
     class Meta:
         verbose_name = 'Publication Series List Page'
@@ -444,6 +449,8 @@ class PublicationSeriesPage(
         FeatureablePageAbstract.feature_panel,
         SearchablePageAbstract.search_panel,
     ]
+
+    search_fields = ContentPage.search_fields + BasicPageAbstract.search_fields
 
     parent_page_types = ['publications.PublicationSeriesListPage']
     subpage_types = []

--- a/research/models.py
+++ b/research/models.py
@@ -179,6 +179,10 @@ class ProjectPage(
         ArchiveablePageAbstract.archive_panel,
     ]
 
+    search_fields = ArchiveablePageAbstract.search_fields \
+        + BasicPageAbstract.search_fields \
+        + ContentPage.search_fields
+
     parent_page_types = ['core.BasicPage', 'research.ProjectListPage']
     subpage_types = []
     templates = 'research/project_page.html'
@@ -216,6 +220,8 @@ class ResearchLandingPage(BasicPageAbstract, Page):
     settings_panels = Page.settings_panels + [
         BasicPageAbstract.submenu_panel,
     ]
+
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
 
     class Meta:
         verbose_name = 'Research Landing Page'
@@ -259,9 +265,10 @@ class TopicPage(ArchiveablePageAbstract, Page):
         ArchiveablePageAbstract.archive_panel,
     ]
 
-    search_fields = Page.search_fields + [
-        index.FilterField('archive'),
-    ]
+    search_fields = Page.search_fields \
+        + ArchiveablePageAbstract.search_fields + [
+            index.FilterField('archive'),
+        ]
 
     parent_page_types = ['research.TopicListPage']
     subpage_types = []

--- a/subscribe/models.py
+++ b/subscribe/models.py
@@ -54,6 +54,8 @@ class SubscribePage(
         )
     ]
 
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+
     max_count = 1
     parent_page_types = ['home.HomePage']
     subpage_types = []


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#558

This issue was caused by certain page classes inheriting from multiple classes that have `search_fields` defined, which led to the subclasses only inheriting the variable from one of the superclasses. 

See https://github.com/wagtail/wagtail/issues/4940