### PR TITLE
CIGI-559: Add multimedia page to expert activity search

### DIFF
--- a/cigionline/static/pages/person_page/index.js
+++ b/cigionline/static/pages/person_page/index.js
@@ -29,16 +29,16 @@ ReactDOM.render(
     limit={14}
     RowComponent={ExpertContentListing}
     tableColumns={[{
-      colSpan: '6',
+      colSpan: 6,
       colTitle: 'Title',
     }, {
-      colSpan: '3',
+      colSpan: 3,
       colTitle: 'Topic',
     }, {
-      colSpan: '2',
+      colSpan: 2,
       colTitle: 'Type',
     }, {
-      colSpan: '1',
+      colSpan: 1,
       colTitle: 'PDF',
     }]}
   />,

--- a/people/search_expert.py
+++ b/people/search_expert.py
@@ -34,8 +34,8 @@ class CIGIOnlineExpertLatestActivitySearchQueryCompiler:
                         }, {
                             "bool": {
                                 "must": [{
-                                    "term": {
-                                        "content_type": "publications.PublicationPage",
+                                    "terms": {
+                                        "content_type": ["publications.PublicationPage", "multimedia.MultimediaPage"],
                                     }
                                 }]
                             }


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#559

- Also fixed react proptype error

![image](https://user-images.githubusercontent.com/40705848/113084077-536cb380-91ab-11eb-9788-542957a11ab3.png)

