### PR TITLE
CIGI-560: Populate admin menu with custom menu items

### DIFF
--- a/annual_reports/wagtail_hooks.py
+++ b/annual_reports/wagtail_hooks.py
@@ -1,0 +1,34 @@
+from .models import AnnualReportPage, AnnualReportListPage
+from wagtail.contrib.modeladmin.options import (ModelAdmin, modeladmin_register, ModelAdminGroup)
+
+
+class AnnualReportListPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = AnnualReportListPage
+    menu_label = 'AnnualReport Landing Page'
+    menu_icon = 'date'
+    menu_order = 100
+    list_display = ('title',)
+
+
+class AnnualReportPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = AnnualReportPage
+    menu_label = 'AnnualReports'
+    menu_icon = 'date'
+    menu_order = 101
+    list_display = ('title', 'year', 'live')
+    list_filter = ('year', 'live')
+    search_fields = ('title', 'year',)
+    ordering = ['-year']
+
+
+class AnnualReportGroup(ModelAdminGroup):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    menu_label = 'AnnualReports'
+    menu_icon = 'date'
+    menu_order = 120
+    items = (AnnualReportListPageAdmin, AnnualReportPageAdmin)
+
+
+modeladmin_register(AnnualReportGroup)

--- a/articles/wagtail_hooks.py
+++ b/articles/wagtail_hooks.py
@@ -1,8 +1,8 @@
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.core import hooks
-from articles.models import ArticlePage
-from wagtail.contrib.modeladmin.options import (ModelAdmin, modeladmin_register)
+from articles.models import ArticlePage, ArticleSeriesPage, ArticleLandingPage
+from wagtail.contrib.modeladmin.options import (ModelAdmin, ModelAdminGroup, modeladmin_register)
 
 from .rich_text import AnchorEntityElementHandler, anchor_entity_decorator
 
@@ -66,7 +66,16 @@ def register_rich_text_anchor(features):
     })
 
 
-class ArticlePageModelAdmin(ModelAdmin):
+class ArticleLandingPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = ArticleLandingPage
+    menu_label = 'Article Landing Page'
+    menu_icon = 'doc-empty-inverse'
+    menu_order = 100
+    list_display = ('title',)
+
+
+class ArticleAdmin(ModelAdmin):
     # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
     model = ArticlePage
     menu_label = 'Articles'
@@ -82,4 +91,24 @@ class ArticlePageModelAdmin(ModelAdmin):
         return qs.filter(publishing_date__isnull=False)
 
 
-modeladmin_register(ArticlePageModelAdmin)
+class ArticleSeriesAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = ArticleSeriesPage
+    menu_label = 'Article Series'
+    menu_icon = 'doc-empty-inverse'
+    menu_order = 102
+    list_display = ('title', 'publishing_date', 'live')
+    list_filter = ('publishing_date', 'live')
+    search_fields = ('title')
+    ordering = ['-publishing_date']
+
+
+class ArticlesGroup(ModelAdminGroup):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    menu_label = 'Articles'
+    menu_icon = 'doc-empty-inverse'
+    menu_order = 101
+    items = (ArticleLandingPageAdmin, ArticleAdmin, ArticleSeriesAdmin)
+
+
+modeladmin_register(ArticlesGroup)

--- a/articles/wagtail_hooks.py
+++ b/articles/wagtail_hooks.py
@@ -75,7 +75,7 @@ class ArticleLandingPageAdmin(ModelAdmin):
     list_display = ('title',)
 
 
-class ArticleAdmin(ModelAdmin):
+class ArticlePageAdmin(ModelAdmin):
     # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
     model = ArticlePage
     menu_label = 'Articles'
@@ -91,7 +91,7 @@ class ArticleAdmin(ModelAdmin):
         return qs.filter(publishing_date__isnull=False)
 
 
-class ArticleSeriesAdmin(ModelAdmin):
+class ArticleSeriesPageAdmin(ModelAdmin):
     # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
     model = ArticleSeriesPage
     menu_label = 'Article Series'
@@ -108,7 +108,7 @@ class ArticlesGroup(ModelAdminGroup):
     menu_label = 'Articles'
     menu_icon = 'doc-empty-inverse'
     menu_order = 101
-    items = (ArticleLandingPageAdmin, ArticleAdmin, ArticleSeriesAdmin)
+    items = (ArticleLandingPageAdmin, ArticlePageAdmin, ArticleSeriesPageAdmin)
 
 
 modeladmin_register(ArticlesGroup)

--- a/events/wagtail_hooks.py
+++ b/events/wagtail_hooks.py
@@ -1,0 +1,34 @@
+from .models import EventPage, EventListPage
+from wagtail.contrib.modeladmin.options import (ModelAdmin, modeladmin_register, ModelAdminGroup)
+
+
+class EventListPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = EventListPage
+    menu_label = 'Event Landing Page'
+    menu_icon = 'date'
+    menu_order = 100
+    list_display = ('title',)
+
+
+class EventPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = EventPage
+    menu_label = 'Events'
+    menu_icon = 'date'
+    menu_order = 101
+    list_display = ('title', 'event_type', 'publishing_date', 'event_end', 'live')
+    list_filter = ('publishing_date', 'live')
+    search_fields = ('title', 'event_type',)
+    ordering = ['-publishing_date']
+
+
+class EventGroup(ModelAdminGroup):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    menu_label = 'Events'
+    menu_icon = 'date'
+    menu_order = 105
+    items = (EventListPageAdmin, EventPageAdmin)
+
+
+modeladmin_register(EventGroup)

--- a/multimedia/wagtail_hooks.py
+++ b/multimedia/wagtail_hooks.py
@@ -1,13 +1,22 @@
-from .models import MultimediaPage
-from wagtail.contrib.modeladmin.options import (ModelAdmin, modeladmin_register)
+from .models import MultimediaPage, MultimediaSeriesPage, MultimediaListPage
+from wagtail.contrib.modeladmin.options import (ModelAdmin, ModelAdminGroup, modeladmin_register)
 
 
-class MultimediaPageModelAdmin(ModelAdmin):
+class MultimediaListPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = MultimediaListPage
+    menu_label = 'Multimedia Landing Page'
+    menu_icon = 'media'
+    menu_order = 100
+    list_display = ('title',)
+
+
+class MultimediaPageAdmin(ModelAdmin):
     # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
     model = MultimediaPage
     menu_label = 'Multimedia'
     menu_icon = 'media'
-    menu_order = 102
+    menu_order = 101
     list_display = ('title', 'publishing_date', 'multimedia_type', 'multimedia_series', 'theme', 'live')
     list_filter = ('publishing_date', 'multimedia_type', 'multimedia_series', 'theme', 'live')
     search_fields = ('title', 'multimedia_type', 'multimedia_series',)
@@ -18,4 +27,24 @@ class MultimediaPageModelAdmin(ModelAdmin):
         return qs.filter(publishing_date__isnull=False)
 
 
-modeladmin_register(MultimediaPageModelAdmin)
+class MultimediaSeriesPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = MultimediaSeriesPage
+    menu_label = 'Multimedia Series'
+    menu_icon = 'media'
+    menu_order = 102
+    list_display = ('title', 'publishing_date', 'live')
+    list_filter = ('publishing_date', 'live')
+    search_fields = ('title',)
+    ordering = ['-publishing_date']
+
+
+class MultimediaGroup(ModelAdminGroup):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    menu_label = 'Multimedia'
+    menu_icon = 'media'
+    menu_order = 102
+    items = (MultimediaListPageAdmin, MultimediaPageAdmin, MultimediaSeriesPageAdmin)
+
+
+modeladmin_register(MultimediaGroup)

--- a/newsletters/wagtail_hooks.py
+++ b/newsletters/wagtail_hooks.py
@@ -7,7 +7,7 @@ class NewsletterPageModelAdmin(ModelAdmin):
     model = NewsletterPage
     menu_label = 'Newsletters'
     menu_icon = 'site'
-    menu_order = 200
+    menu_order = 110
     list_display = ('title', 'live', 'html_file', 'latest_revision_created_at')
     list_filter = ('live', 'latest_revision_created_at')
     search_fields = ('title')

--- a/people/wagtail_hooks.py
+++ b/people/wagtail_hooks.py
@@ -28,7 +28,7 @@ class PersonPageAdmin(ModelAdmin):
     get_person_type.admin_order_field = 'person_types__name'
 
 
-class PersonGroup(ModelAdminGroup):
+class PeopleGroup(ModelAdminGroup):
     # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
     menu_label = 'People'
     menu_icon = 'group'
@@ -36,4 +36,4 @@ class PersonGroup(ModelAdminGroup):
     items = (PersonListPageAdmin, PersonPageAdmin)
 
 
-modeladmin_register(PersonGroup)
+modeladmin_register(PeopleGroup)

--- a/people/wagtail_hooks.py
+++ b/people/wagtail_hooks.py
@@ -17,8 +17,8 @@ class PersonPageAdmin(ModelAdmin):
     menu_label = 'People'
     menu_icon = 'group'
     menu_order = 101
-    list_display = ('title', 'get_person_type', 'latest_revision_created_at', 'live')
-    list_filter = ('latest_revision_created_at', 'person_types__name', 'live')
+    list_display = ('title', 'get_person_type', 'latest_revision_created_at', 'archive', 'live')
+    list_filter = ('latest_revision_created_at', 'person_types__name', 'archive', 'live')
     search_fields = ('title',)
     ordering = ['-latest_revision_created_at']
 

--- a/people/wagtail_hooks.py
+++ b/people/wagtail_hooks.py
@@ -1,0 +1,41 @@
+from .models import PersonPage, PersonListPage
+from wagtail.contrib.modeladmin.options import (ModelAdmin, modeladmin_register, ModelAdminGroup)
+
+
+class PersonListPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = PersonListPage
+    menu_label = 'People List Pages'
+    menu_icon = 'group'
+    menu_order = 100
+    list_display = ('title',)
+
+
+class PersonPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = PersonPage
+    menu_label = 'People'
+    menu_icon = 'group'
+    menu_order = 101
+    list_display = ('title', 'get_person_type', 'latest_revision_created_at', 'live')
+    list_filter = ('latest_revision_created_at', 'person_types__name', 'live')
+    search_fields = ('title',)
+    ordering = ['-latest_revision_created_at']
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.filter(person_types__name__in=['Expert', 'External profile'])
+
+    def get_person_type(self, person):
+        return [person_type.name for person_type in person.person_types.all()]
+
+
+class PersonGroup(ModelAdminGroup):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    menu_label = 'People'
+    menu_icon = 'group'
+    menu_order = 200
+    items = (PersonListPageAdmin, PersonPageAdmin)
+
+
+modeladmin_register(PersonGroup)

--- a/people/wagtail_hooks.py
+++ b/people/wagtail_hooks.py
@@ -22,12 +22,10 @@ class PersonPageAdmin(ModelAdmin):
     search_fields = ('title',)
     ordering = ['-latest_revision_created_at']
 
-    def get_queryset(self, request):
-        qs = super().get_queryset(request)
-        return qs.filter(person_types__name__in=['Expert', 'External profile'])
-
     def get_person_type(self, person):
         return [person_type.name for person_type in person.person_types.all()]
+    get_person_type.short_description = 'Person Types'
+    get_person_type.admin_order_field = 'person_types__name'
 
 
 class PersonGroup(ModelAdminGroup):

--- a/promotions/wagtail_hooks.py
+++ b/promotions/wagtail_hooks.py
@@ -7,7 +7,7 @@ class PromotionBlockModelAdmin(ModelAdmin):
     model = PromotionBlock
     menu_label = 'Promotion Blocks'
     menu_icon = 'image'
-    menu_order = 900
+    menu_order = 300
     list_display = ('name', 'block_type')
     list_filter = ('block_type',)
     search_fields = ('name',)

--- a/publications/wagtail_hooks.py
+++ b/publications/wagtail_hooks.py
@@ -29,7 +29,7 @@ class PublicationPageAdmin(ModelAdmin):
 
 class PublicationSeriesPageAdmin(ModelAdmin):
     # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
-    model = PublicationPage
+    model = PublicationSeriesPage
     menu_label = 'Publication Series'
     menu_icon = 'doc-full'
     menu_order = 102

--- a/publications/wagtail_hooks.py
+++ b/publications/wagtail_hooks.py
@@ -1,13 +1,22 @@
-from publications.models import PublicationPage
-from wagtail.contrib.modeladmin.options import (ModelAdmin, modeladmin_register)
+from publications.models import PublicationPage, PublicationSeriesPage, PublicationListPage
+from wagtail.contrib.modeladmin.options import (ModelAdmin, ModelAdminGroup, modeladmin_register)
 
 
-class PublicationPageModelAdmin(ModelAdmin):
+class PublicationListPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = PublicationListPage
+    menu_label = 'Publication Landing Page'
+    menu_icon = 'doc-full'
+    menu_order = 100
+    list_display = ('title',)
+
+
+class PublicationPageAdmin(ModelAdmin):
     # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
     model = PublicationPage
     menu_label = 'Publications'
     menu_icon = 'doc-full'
-    menu_order = 103
+    menu_order = 101
     list_display = ('title', 'publishing_date', 'publication_type', 'live', 'publication_series')
     list_filter = ('publishing_date', 'publication_type', 'live', 'publication_series')
     search_fields = ('title')
@@ -18,4 +27,24 @@ class PublicationPageModelAdmin(ModelAdmin):
         return qs.filter(publishing_date__isnull=False)
 
 
-modeladmin_register(PublicationPageModelAdmin)
+class PublicationSeriesPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = PublicationPage
+    menu_label = 'Publication Series'
+    menu_icon = 'doc-full'
+    menu_order = 102
+    list_display = ('title', 'publishing_date', 'live',)
+    list_filter = ('publishing_date', 'live',)
+    search_fields = ('title')
+    ordering = ['-publishing_date']
+
+
+class PublicationsGroup(ModelAdminGroup):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    menu_label = 'Publications'
+    menu_icon = 'doc-full'
+    menu_order = 103
+    items = (PublicationListPageAdmin, PublicationPageAdmin, PublicationSeriesPageAdmin)
+
+
+modeladmin_register(PublicationsGroup)

--- a/research/wagtail_hooks.py
+++ b/research/wagtail_hooks.py
@@ -1,0 +1,50 @@
+from .models import ProjectPage, TopicPage, ResearchLandingPage
+from wagtail.contrib.modeladmin.options import (ModelAdmin, ModelAdminGroup, modeladmin_register)
+
+
+class ResearchLandingPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = ResearchLandingPage
+    menu_label = 'Research Landing Page'
+    menu_icon = 'form'
+    menu_order = 100
+    list_display = ('title',)
+
+
+class ProjectPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = ProjectPage
+    menu_label = 'Projects'
+    menu_icon = 'form'
+    menu_order = 101
+    list_display = ('title', 'publishing_date', 'project_types', 'live')
+    list_filter = ('publishing_date', 'project_types', 'live')
+    search_fields = ('title', 'project_types',)
+    ordering = ['-publishing_date']
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.filter(publishing_date__isnull=False)
+
+
+class TopicPageAdmin(ModelAdmin):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    model = TopicPage
+    menu_label = 'Topics'
+    menu_icon = 'snippet'
+    menu_order = 102
+    list_display = ('title', 'live')
+    list_filter = ('live')
+    search_fields = ('title',)
+    ordering = ['title']
+
+
+class ResearchGroup(ModelAdminGroup):
+    # See https://docs.wagtail.io/en/stable/reference/contrib/modeladmin/
+    menu_label = 'Research'
+    menu_icon = 'form'
+    menu_order = 104
+    items = (ResearchLandingPageAdmin, ProjectPageAdmin, TopicPageAdmin)
+
+
+modeladmin_register(ResearchGroup)

--- a/research/wagtail_hooks.py
+++ b/research/wagtail_hooks.py
@@ -34,7 +34,7 @@ class TopicPageAdmin(ModelAdmin):
     menu_icon = 'snippet'
     menu_order = 102
     list_display = ('title', 'live')
-    list_filter = ('live')
+    list_filter = ('live',)
     search_fields = ('title',)
     ordering = ['title']
 


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#560

Added submenus for:
- Articles
- Publications
- Multimedia
- Events
- People

![image](https://user-images.githubusercontent.com/40705848/113203160-aab96500-9239-11eb-8519-2d34f2446dcd.png)
