### PR TITLE
Increase production static asset cache to 1 year

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -53,7 +53,7 @@ http {
 
 		<% if ENV['STATIC_PROXY'] %>
 			location /static/ {
-				add_header Cache-Control "public, max-age=86400";
+				add_header Cache-Control "public, max-age=604800";
 				proxy_pass http://<%= ENV['STATIC_PROXY'] %>/static/;
 			}
 		<% end %>

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -53,7 +53,7 @@ http {
 
 		<% if ENV['STATIC_PROXY'] %>
 			location /static/ {
-				add_header Cache-Control "public, max-age=604800";
+				add_header Cache-Control "public, max-age=31536000";
 				proxy_pass http://<%= ENV['STATIC_PROXY'] %>/static/;
 			}
 		<% end %>


### PR DESCRIPTION
Now that the static assets are fingerprinted in production, the files should never change. Thus, we can set the cache to a year as defined in [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):
```
To mark a response as "never expires," an origin server sends an Expires date approximately one year from the time the response is sent. HTTP/1.1 servers SHOULD NOT send Expires dates more than one year in the future.
```