### PR TITLE
CIGI-567: Return empty result if searchpage and searchtest is empty

### DIFF
--- a/cigionline/static/js/components/SearchTable.js
+++ b/cigionline/static/js/components/SearchTable.js
@@ -172,6 +172,9 @@ class SearchTable extends React.Component {
     if (typeSelected && typeSelected.param) {
       uri += `&${typeSelected.param}=${typeSelected.value}`;
     }
+    if (isSearchPage) {
+      uri += '&searchpage=true';
+    }
 
     fetch(encodeURI(uri))
       .then((res) => res.json())

--- a/search/views.py
+++ b/search/views.py
@@ -16,6 +16,13 @@ def search_api(request):
 
         # Record hit
         query.add_hit()
+    elif request.GET.get('searchpage'):
+        return JsonResponse({
+            'meta': {
+                'total_count': 0,
+            },
+            'items': [],
+        }, safe=False)
 
     pages = cigi_search(
         articletypeid=request.GET.get('articletypeid', None),


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#567

- This only applies to search page, as all other search components should be populated with initial data
