### PR TITLE
Refactor featured queries

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -32,47 +32,18 @@ class ArticleLandingPage(BasicPageAbstract, Page):
     subpage_types = []
     templates = 'articles/article_landing_page.html'
 
-    def featured_xlarge(self):
-        return self.featured_articles.prefetch_related(
-            'article_page',
-            'article_page__authors__author',
-            'article_page__topics',
-        ).all()[0:1]
+    def get_featured_articles(self):
+        featured_article_ids = self.featured_articles.order_by('sort_order').values_list('article_page', flat=True)
+        pages = Page.objects.specific().prefetch_related(
+            'authors__author',
+            'topics',
+        ).in_bulk(featured_article_ids)
+        return [pages[x] for x in featured_article_ids]
 
-    def featured_large_1(self):
-        return self.featured_articles.prefetch_related(
-            'article_page',
-            'article_page__authors__author',
-            'article_page__topics',
-        ).all()[1:2]
-
-    def featured_small_1(self):
-        return self.featured_articles.prefetch_related(
-            'article_page',
-            'article_page__authors__author',
-            'article_page__topics',
-        ).all()[2:7]
-
-    def featured_medium_1(self):
-        return self.featured_articles.prefetch_related(
-            'article_page',
-            'article_page__authors__author',
-            'article_page__topics',
-        ).all()[7:9]
-
-    def featured_small_2(self):
-        return self.featured_articles.prefetch_related(
-            'article_page',
-            'article_page__authors__author',
-            'article_page__topics',
-        ).all()[10:15]
-
-    def featured_large_2(self):
-        return self.featured_articles.prefetch_related(
-            'article_page',
-            'article_page__authors__author',
-            'article_page__topics',
-        ).all()[9:10]
+    def get_context(self, request):
+        context = super().get_context(request)
+        context['featured_articles'] = self.get_featured_articles()
+        return context
 
     def all_article_series(self):
         return ArticleSeriesPage.objects.prefetch_related(

--- a/articles/models.py
+++ b/articles/models.py
@@ -40,15 +40,16 @@ class ArticleLandingPage(BasicPageAbstract, Page):
         ).in_bulk(featured_article_ids)
         return [pages[x] for x in featured_article_ids]
 
-    def get_context(self, request):
-        context = super().get_context(request)
-        context['featured_articles'] = self.get_featured_articles()
-        return context
-
-    def all_article_series(self):
+    def get_featured_article_series(self):
         return ArticleSeriesPage.objects.prefetch_related(
             'topics',
         ).live().public().order_by('-publishing_date')[:10]
+
+    def get_context(self, request):
+        context = super().get_context(request)
+        context['featured_articles'] = self.get_featured_articles()
+        context['featured_article_series'] = self.get_featured_article_series()
+        return context
 
     content_panels = Page.content_panels + [
         MultiFieldPanel(

--- a/home/models.py
+++ b/home/models.py
@@ -133,25 +133,24 @@ class HomePage(Page):
             featured_events = future_events
         return featured_events
 
-    def get_context(self, request):
-        context = super().get_context(request)
-
-        context['featured_pages'] = self.get_featured_pages()
-        context['featured_experts'] = self.get_featured_experts()
-        context['highlight_pages'] = self.get_highlight_pages()
-        context['featured_multimedia'] = self.get_featured_multimedia()
-        context['featured_publications'] = self.get_featured_publications()
-        context['featured_events'] = self.get_featured_events()
-
-        return context
-
-    def promotion_blocks_list(self):
+    def get_promotion_blocks(self):
         promotion_blocks_list = []
         for item in self.promotion_blocks.prefetch_related(
             'promotion_block',
         ).all()[:2]:
             promotion_blocks_list.append(item.promotion_block)
         return promotion_blocks_list
+
+    def get_context(self, request):
+        context = super().get_context(request)
+        context['featured_pages'] = self.get_featured_pages()
+        context['featured_experts'] = self.get_featured_experts()
+        context['highlight_pages'] = self.get_highlight_pages()
+        context['featured_multimedia'] = self.get_featured_multimedia()
+        context['featured_publications'] = self.get_featured_publications()
+        context['featured_events'] = self.get_featured_events()
+        context['promotion_blocks'] = self.get_promotion_blocks()
+        return context
 
     max_count = 1
     subpage_types = [

--- a/home/models.py
+++ b/home/models.py
@@ -109,57 +109,13 @@ class HomePage(Page):
         ).in_bulk(featured_multimedia_ids)
         return [multimedia[x] for x in featured_multimedia_ids]
 
-    def get_context(self, request):
-        context = super().get_context(request)
-
-        context['featured_pages'] = self.get_featured_pages()
-        context['featured_experts'] = self.get_featured_experts()
-        context['highlight_pages'] = self.get_highlight_pages()
-        context['featured_multimedia'] = self.get_featured_multimedia()
-
-        return context
-
-    def featured_publications(self):
+    def get_featured_publications(self):
         return PublicationPage.objects.prefetch_related(
             'authors__author',
             'topics',
         ).live().public().order_by('-publishing_date')[:4]
 
-    def featured_multimedia_large(self):
-        first_featured_multimedia = self.featured_multimedia.prefetch_related(
-            'featured_multimedia__authors__author',
-            'featured_multimedia__topics',
-        ).first()
-        if first_featured_multimedia:
-            return first_featured_multimedia.featured_multimedia
-        return False
-
-    def featured_multimedia_small(self):
-        featured_multimedia_small = []
-        for item in self.featured_multimedia.prefetch_related(
-            'featured_multimedia__authors__author',
-            'featured_multimedia__topics',
-        ).all()[1:]:
-            featured_multimedia_small.append(item.featured_multimedia)
-        return featured_multimedia_small
-
-    def featured_experts_list(self):
-        featured_experts = []
-        for item in self.featured_experts.prefetch_related(
-            'featured_expert',
-        ).all()[:3]:
-            featured_experts.append(item.featured_expert)
-        return featured_experts
-
-    def promotion_blocks_list(self):
-        promotion_blocks_list = []
-        for item in self.promotion_blocks.prefetch_related(
-            'promotion_block',
-        ).all()[:2]:
-            promotion_blocks_list.append(item.promotion_block)
-        return promotion_blocks_list
-
-    def featured_events(self):
+    def get_featured_events(self):
         featured_events = []
         now = timezone.now()
         future_events = EventPage.objects.prefetch_related(
@@ -176,6 +132,26 @@ class HomePage(Page):
         else:
             featured_events = future_events
         return featured_events
+
+    def get_context(self, request):
+        context = super().get_context(request)
+
+        context['featured_pages'] = self.get_featured_pages()
+        context['featured_experts'] = self.get_featured_experts()
+        context['highlight_pages'] = self.get_highlight_pages()
+        context['featured_multimedia'] = self.get_featured_multimedia()
+        context['featured_publications'] = self.get_featured_publications()
+        context['featured_events'] = self.get_featured_events()
+
+        return context
+
+    def promotion_blocks_list(self):
+        promotion_blocks_list = []
+        for item in self.promotion_blocks.prefetch_related(
+            'promotion_block',
+        ).all()[:2]:
+            promotion_blocks_list.append(item.promotion_block)
+        return promotion_blocks_list
 
     max_count = 1
     subpage_types = [

--- a/templates/articles/article_landing_page.html
+++ b/templates/articles/article_landing_page.html
@@ -83,7 +83,7 @@
         <div class="row">
           <div class="col-12">
             <h2 class="paragraph-heading">Series</h2>
-            {% include "includes/swiper.html" with swiper_content=self.all_article_series type="article-landing-series" %}
+            {% include "includes/swiper.html" with swiper_content=featured_article_series type="article-landing-series" %}
           </div>
         </div>
       </div>

--- a/templates/articles/article_landing_page.html
+++ b/templates/articles/article_landing_page.html
@@ -19,54 +19,60 @@
       </div>
       <div class="row">
         <div class="col-12">
-          {% for item in self.featured_xlarge %}
-            {% include "includes/features/feature_content_xlarge.html" with content=item.article_page.specific %}
-          {% endfor %}
-        </div>
-      </div>
-      <hr>
-      <div class="row">
-        <div class="col-12 col-md-8">
-          {% for item in self.featured_large_1 %}
-            {% include "includes/features/feature_content_large.html" with content=item.article_page.specific %}
-          {% endfor %}
-        </div>
-        <hr>
-        <div class="col-12 col-md-4 featured-small">
-          {% for item in self.featured_small_1 %}
-            {% if forloop.counter > 1 %}
-              <hr>
-            {% endif %}
-            {% include "includes/features/feature_content_small.html" with content=item.article_page.specific %}
-          {% endfor %}
-        </div>
-      </div>
-      <hr>
-      <div class="row">
-        {% for item in self.featured_medium_1 %}
-          {% if forloop.counter > 1 %}
-            <hr>
+          {% if featured_articles|length > 0 %}
+            {% include "includes/features/feature_content_xlarge.html" with content=featured_articles.0 %}
           {% endif %}
-          <div class="col-12 col-md-6">
-            {% include "includes/features/feature_content_medium.html" with content=item.article_page.specific with_subtitle=True %}
-          </div>
-        {% endfor %}
+        </div>
+      </div>
+      <hr>
+      <div class="row">
+        <div class="col-12 col-md-8">
+          {% if featured_articles|length > 1 %}
+            {% include "includes/features/feature_content_large.html" with content=featured_articles.1 %}
+          {% endif %}
+        </div>
+        <hr>
+        <div class="col-12 col-md-4 featured-small">
+          {% with featured_articles|slice:"2:7" as featured_small %}
+            {% for item in featured_small %}
+              {% if forloop.counter > 1 %}
+                <hr>
+              {% endif %}
+              {% include "includes/features/feature_content_small.html" with content=item %}
+            {% endfor %}
+          {% endwith %}
+        </div>
+      </div>
+      <hr>
+      <div class="row">
+        {% with featured_articles|slice:"7:9" as featured_medium %}
+          {% for item in featured_medium %}
+            {% if forloop.counter > 1 %}
+              <hr>
+            {% endif %}
+            <div class="col-12 col-md-6">
+              {% include "includes/features/feature_content_medium.html" with content=item with_subtitle=True %}
+            </div>
+          {% endfor %}
+        {% endwith %}
       </div>
       <hr>
       <div class="row">
         <div class="col-12 col-md-4 featured-small">
-          {% for item in self.featured_small_2 %}
-            {% if forloop.counter > 1 %}
-              <hr>
-            {% endif %}
-            {% include "includes/features/feature_content_small.html" with content=item.article_page.specific %}
-          {% endfor %}
+          {% with featured_articles|slice:"10:15" as featured_small %}
+            {% for item in featured_small %}
+              {% if forloop.counter > 1 %}
+                <hr>
+              {% endif %}
+              {% include "includes/features/feature_content_small.html" with content=item %}
+            {% endfor %}
+          {% endwith %}
         </div>
         <hr>
         <div class="col-12 col-md-8">
-          {% for item in self.featured_large_2 %}
-            {% include "includes/features/feature_content_large.html" with content=item.article_page.specific %}
-          {% endfor %}
+          {% if featured_articles|length > 9 %}
+            {% include "includes/features/feature_content_large.html" with content=featured_articles.9 %}
+          {% endif %}
         </div>
       </div>
     </div>

--- a/templates/events/event_list_page.html
+++ b/templates/events/event_list_page.html
@@ -15,9 +15,9 @@
     <div class="container">
       <h2>Featured</h2>
       <div class="row featured-event-row">
-        {% for event in self.featured_events_list %}
+        {% for item in featured_events %}
           <div class="col-md-4 featured-event-col">
-            {% include "includes/features/feature_event.html" with event=event %}
+            {% include "includes/features/feature_event.html" with event=item %}
           </div>
         {% endfor %}
       </div>

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -73,7 +73,7 @@
   <section class="homepage-promotion-blocks">
     <div class="container">
       <div class="row">
-        {% for promotion_block in self.promotion_blocks_list %}
+        {% for promotion_block in promotion_blocks %}
           <div class="homepage-promotion-block col-md-6">
             {% include "includes/promotion_block.html" with promotion_block=promotion_block %}
           </div>

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -62,7 +62,7 @@
         </div>
       </div>
       <div class="row">
-        {% for publication in self.featured_publications %}
+        {% for publication in featured_publications %}
           <div class="col-12 col-md-3 homepage-featured-publication-row">
             {% include "includes/features/feature_publication_teaser.html" with publication=publication %}
           </div>
@@ -138,7 +138,7 @@
         </div>
       </div>
       <div class="events-container row">
-        {% for event in self.featured_events %}
+        {% for event in featured_events %}
           <div class="col-12 col-md-4 homepage-featured-event-row">
             {% include "includes/features/feature_event.html" with event=event %}
           </div>

--- a/templates/multimedia/multimedia_list_page.html
+++ b/templates/multimedia/multimedia_list_page.html
@@ -20,18 +20,20 @@
       </div>
       <div class="row">
         <div class="col-12 col-md-8">
-          {% for item in self.featured_large %}
-            {% include "includes/features/feature_content_large.html" with content=item.multimedia_page.specific %}
-          {% endfor %}
+          {% if featured_multimedia|length > 0 %}
+            {% include "includes/features/feature_content_large.html" with content=featured_multimedia.0 %}
+          {% endif %}
         </div>
         <hr>
         <div class="col-12 col-md-4 featured-small">
-          {% for item in self.featured_small %}
-            {% if forloop.counter > 1 %}
-              <hr>
-            {% endif %}
-            {% include "includes/features/feature_content_small.html" with content=item.multimedia_page.specific %}
-          {% endfor %}
+          {% with featured_multimedia|slice:"1:" as featured_small %}
+            {% for item in featured_small %}
+              {% if forloop.counter > 1 %}
+                <hr>
+              {% endif %}
+              {% include "includes/features/feature_content_small.html" with content=item %}
+            {% endfor %}
+          {% endwith %}
         </div>
       </div>
     </div>
@@ -39,7 +41,7 @@
   <section class="multimedia-promotion-blocks">
     <div class="container">
       <div class="row">
-        {% for promotion_block in self.promotion_blocks_list %}
+        {% for promotion_block in promotion_blocks %}
           <div class="col">
             {% include "includes/promotion_block.html" with promotion_block=promotion_block.promotion_block %}
           </div>


### PR DESCRIPTION
Refactored the featured queries on the Opinions, Multimedia, and Events pages to match the optimizations done to the home page in #1170.

See the before/after table for response time and queries. Note that the home page was only optimized to update the promotion blocks query, which resulted in removing just a single query.

Page | Before - Time | Before - Queries | After - Time | After - Queries
--- | --- | --- | --- | ---
Home | 10714.93ms | 175 queries in 265.54ms | 10397.40ms | 174 queries in 271.81ms
Opinions | 9065.69ms | 183 queries in 217.63ms | 5820.57ms | 111 queries in 116.16ms
Multimedia | 2664.04ms | 54 queries in 58.63ms | 1853.61ms | 34 queries in 51.02ms
Events | 4101.96ms | 31 queries in 178.17ms | 1463.13ms | 22 queries in 39.37ms