### PR TITLE
Add request context to highlighted topics template

### DIFF
--- a/research/templatetags/topic_tags.py
+++ b/research/templatetags/topic_tags.py
@@ -5,10 +5,13 @@ from django.db.models import Count
 register = template.Library()
 
 
-@register.inclusion_tag('research/highlighted_topics.html')
-def highlighted_topics():
+@register.inclusion_tag('research/highlighted_topics.html', takes_context=True)
+def highlighted_topics(context):
     highlighted_topics = TopicPage.objects.live().filter(archive=0).order_by('title').annotate(count=Count('content_pages'))
-    return {'highlighted_topics': highlighted_topics}
+    return {
+        'highlighted_topics': highlighted_topics,
+        'request': context['request'],
+    }
 
 
 @register.inclusion_tag('research/topics.html')

--- a/research/templatetags/topic_tags.py
+++ b/research/templatetags/topic_tags.py
@@ -8,10 +8,12 @@ register = template.Library()
 @register.inclusion_tag('research/highlighted_topics.html', takes_context=True)
 def highlighted_topics(context):
     highlighted_topics = TopicPage.objects.live().filter(archive=0).order_by('title').annotate(count=Count('content_pages'))
-    return {
+    result = {
         'highlighted_topics': highlighted_topics,
-        'request': context['request'],
     }
+    if context and context['request']:
+        result['request'] = context['request']
+    return result
 
 
 @register.inclusion_tag('research/topics.html')

--- a/research/templatetags/topic_tags.py
+++ b/research/templatetags/topic_tags.py
@@ -11,7 +11,7 @@ def highlighted_topics(context):
     result = {
         'highlighted_topics': highlighted_topics,
     }
-    if context and context['request']:
+    if context and hasattr(context, 'request'):
         result['request'] = context['request']
     return result
 

--- a/templates/includes/recommended.html
+++ b/templates/includes/recommended.html
@@ -10,12 +10,12 @@
         <div class="recommended-content-medium row">
           {% for content in recommended|slice:":3" %}
             <div class="col-md-4">
-              {% include 'includes/features/feature_content_medium.html' with content=content.specific %}
+              {% include 'includes/features/feature_content_medium.html' with content=content %}
             </div>
           {% endfor %}
           {% for content in recommended|slice:"3:" %}
             <div class="col-md-4">
-              {% include 'includes/features/feature_content_small.html' with content=content.specific icon=True %}
+              {% include 'includes/features/feature_content_small.html' with content=content icon=True %}
             </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
The highlighted topics in the footer is a chunk of the queries on any given page - the majority just querying the correct URL to link with `{% pageurl %}. I added the request context to the template so that the `pageurl` template tag doesn't have to query for the default site. See the table below for response times on an article page. Note that these response times are quite high as I was testing with Django's dummy cache to get consistent results. Actual load times should be much smaller.

Page | Before - Time | Before - Queries | After - Time | After - Queries
--- | --- | --- | --- | ---
Article page | 8109.15ms | 106 queries in 253.61ms | 4850.56ms | 80 queries in 179.48ms