### PR TITLE
Use cached property instead of counting authors

### DIFF
--- a/cigionline/settings/dev.py
+++ b/cigionline/settings/dev.py
@@ -12,13 +12,31 @@ ALLOWED_HOSTS = ['*']
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Uncomment this to enable Django debug toolbar
-# INSTALLED_APPS = INSTALLED_APPS + [
-#     'debug_toolbar',
-# ]
-#
-# MIDDLEWARE = MIDDLEWARE + [
-#     'debug_toolbar.middleware.DebugToolbarMiddleware',
-# ]
+INSTALLED_APPS = INSTALLED_APPS + [
+    'debug_toolbar',
+    'template_profiler_panel',
+]
+
+MIDDLEWARE = MIDDLEWARE + [
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+]
+DEBUG_TOOLBAR_PANELS = [
+    'debug_toolbar.panels.history.HistoryPanel',
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+    'debug_toolbar.panels.templates.TemplatesPanel',
+    'debug_toolbar.panels.cache.CachePanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.redirects.RedirectsPanel',
+    'debug_toolbar.panels.profiling.ProfilingPanel',
+    'template_profiler_panel.panels.template.TemplateProfilerPanel',
+]
 
 CACHES = {
     'default': {

--- a/cigionline/settings/dev.py
+++ b/cigionline/settings/dev.py
@@ -12,31 +12,31 @@ ALLOWED_HOSTS = ['*']
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Uncomment this to enable Django debug toolbar
-INSTALLED_APPS = INSTALLED_APPS + [
-    'debug_toolbar',
-    'template_profiler_panel',
-]
-
-MIDDLEWARE = MIDDLEWARE + [
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-]
-DEBUG_TOOLBAR_PANELS = [
-    'debug_toolbar.panels.history.HistoryPanel',
-    'debug_toolbar.panels.versions.VersionsPanel',
-    'debug_toolbar.panels.timer.TimerPanel',
-    'debug_toolbar.panels.settings.SettingsPanel',
-    'debug_toolbar.panels.headers.HeadersPanel',
-    'debug_toolbar.panels.request.RequestPanel',
-    'debug_toolbar.panels.sql.SQLPanel',
-    'debug_toolbar.panels.staticfiles.StaticFilesPanel',
-    'debug_toolbar.panels.templates.TemplatesPanel',
-    'debug_toolbar.panels.cache.CachePanel',
-    'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
-    'debug_toolbar.panels.redirects.RedirectsPanel',
-    'debug_toolbar.panels.profiling.ProfilingPanel',
-    'template_profiler_panel.panels.template.TemplateProfilerPanel',
-]
+# INSTALLED_APPS = INSTALLED_APPS + [
+#     'debug_toolbar',
+#     'template_profiler_panel',
+# ]
+#
+# MIDDLEWARE = MIDDLEWARE + [
+#     'debug_toolbar.middleware.DebugToolbarMiddleware',
+# ]
+# DEBUG_TOOLBAR_PANELS = [
+#     'debug_toolbar.panels.history.HistoryPanel',
+#     'debug_toolbar.panels.versions.VersionsPanel',
+#     'debug_toolbar.panels.timer.TimerPanel',
+#     'debug_toolbar.panels.settings.SettingsPanel',
+#     'debug_toolbar.panels.headers.HeadersPanel',
+#     'debug_toolbar.panels.request.RequestPanel',
+#     'debug_toolbar.panels.sql.SQLPanel',
+#     'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+#     'debug_toolbar.panels.templates.TemplatesPanel',
+#     'debug_toolbar.panels.cache.CachePanel',
+#     'debug_toolbar.panels.signals.SignalsPanel',
+#     'debug_toolbar.panels.logging.LoggingPanel',
+#     'debug_toolbar.panels.redirects.RedirectsPanel',
+#     'debug_toolbar.panels.profiling.ProfilingPanel',
+#     'template_profiler_panel.panels.template.TemplateProfilerPanel',
+# ]
 
 CACHES = {
     'default': {

--- a/core/models.py
+++ b/core/models.py
@@ -378,9 +378,14 @@ class ContentPage(Page, SearchablePageAbstract):
             return self.specific.pdf_downloads[0].value['file'].url
         return ''
 
+    @cached_property
     def author_count(self):
         # @todo test this
         return self.authors.count()
+
+    @cached_property
+    def editor_count(self):
+        return self.editors.count()
 
     def get_recommended(self):
         recommended_page_ids = self.recommended.values_list('recommended_content_page_id', flat=True)[:3]

--- a/publications/models.py
+++ b/publications/models.py
@@ -264,7 +264,7 @@ class PublicationPage(
         """
 
         # @todo test
-        return (self.authors.count() + self.editors.count()) > 3
+        return (self.author_count + self.editor_count) > 3
 
     def has_book_metadata(self):
         return (

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -132,7 +132,7 @@
       {% include 'includes/disclaimer.html' %}
 
       {% if self.is_opinion and self.author_count > 0 %}
-        {% include "includes/about_the_author.html" with authors=self.authors.all %}
+        {% include "includes/about_the_author.html" with authors=self.authors.all author_count=self.author_count %}
       {% endif %}
 
     {% endblock %}

--- a/templates/events/event_page.html
+++ b/templates/events/event_page.html
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block content %}
-  {% include "includes/heroes/hero_event.html" with topics=self.topics_sorted title=self.title date=self.publishing_date end_date=self.event_end event_type=self.get_event_type_display event_access=self.get_event_access_display authors=self.authors.all registration_url=self.registration_url %}
+  {% include "includes/heroes/hero_event.html" with topics=self.topics_sorted title=self.title date=self.publishing_date end_date=self.event_end event_type=self.get_event_type_display event_access=self.get_event_access_display authors=self.authors.all author_count=self.author_count registration_url=self.registration_url %}
 
   {% if self.multimedia_page and self.multimedia_page.specific.multimedia_url %}
     <section class="event-multimedia-embed-section">

--- a/templates/events/event_page.html
+++ b/templates/events/event_page.html
@@ -71,7 +71,7 @@
   {% include "includes/body.html" with body=self.body %}
 
   {% if self.author_count > 0 %}
-    {% include "includes/about_the_author.html" with authors=self.authors.all title_override="Event Speaker"%}
+    {% include "includes/about_the_author.html" with authors=self.authors.all author_count=self.author_count title_override="Event Speaker"%}
   {% endif %}
 
   {% if self.related_files %}

--- a/templates/includes/about_the_author.html
+++ b/templates/includes/about_the_author.html
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row justify-content-center">
       <div class="col col-md-10 col-lg-8">
-        <h3>{% if title_override %}{{ title_override }}{% else %}About the Author{% endif %}{{authors|length|pluralize}}</h3>
+        <h3>{% if title_override %}{{ title_override }}{% else %}About the Author{% endif %}{{author_count|length|pluralize}}</h3>
         {% for item in authors %}
           {% if item.author %}
             {% define item.author as person %}

--- a/templates/includes/about_the_author.html
+++ b/templates/includes/about_the_author.html
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row justify-content-center">
       <div class="col col-md-10 col-lg-8">
-        <h3>{% if title_override %}{{ title_override }}{% else %}About the Author{% endif %}{{author_count|length|pluralize}}</h3>
+        <h3>{% if title_override %}{{ title_override }}{% else %}About the Author{% endif %}{{author_count|pluralize}}</h3>
         {% for item in authors %}
           {% if item.author %}
             {% define item.author as person %}

--- a/templates/includes/heroes/hero_event.html
+++ b/templates/includes/heroes/hero_event.html
@@ -23,9 +23,9 @@
           <div class="meta">{{ event_access }} Event{% if event_type|length > 1 %}: {{ event_type }}{% endif %}</div>
         {% endif %}
 
-        {% if authors|length > 0 %}
+        {% if author_count > 0 %}
           <div class="meta speakers">
-            Speaker{{ authors|length|pluralize }}:
+            Speaker{{ author_count|pluralize }}:
             <ul class="custom-text-list">
               {% for item in authors %}
                 {% if item.hide_link %}

--- a/templates/includes/heroes/hero_publication_book.html
+++ b/templates/includes/heroes/hero_publication_book.html
@@ -8,10 +8,10 @@
         <h1>{{ title }}</h1>
         <h2>{{subtitle|safe}}</h2>
         <div class="meta"><span class="label">Published:</span> {% include "includes/date.html" with date=self.publishing_date %}</div>
-        {% if editors|length > 0 %}
-          <div class="meta"><span class="label">Edited by:</span>  {% include "includes/authors.html" with authors=self.editors.all %}</div>
-        {% elif authors|length > 0 %}
-          <div class="meta"><span class="label">Author{{ self.authors|length|pluralize }}:</span>  {% include "includes/authors.html" with authors=self.authors.all %}</div>
+        {% if editor_count > 0 %}
+          <div class="meta"><span class="label">Edited by:</span>  {% include "includes/authors.html" with authors=editors %}</div>
+        {% elif author_count > 0 %}
+          <div class="meta"><span class="label">Author{{ author_count|pluralize }}:</span>  {% include "includes/authors.html" with authors=authors %}</div>
         {% endif %}
         {% include "includes/social_links.html" with title=self.title %}
         {% if purchase_links %}

--- a/templates/publications/publication_page.html
+++ b/templates/publications/publication_page.html
@@ -58,7 +58,7 @@
   {% cache 604800 publication_content request.path request.user.username self.pk self.latest_revision_created_at|date:"c" request.GET.urlencode is_preview %}
     {% block hero %}
       {% if self.publication_type.title == 'Books' %}
-        {% include "includes/heroes/hero_publication_book.html" with title=self.title subtitle=self.subtitle purchase_links=self.book_purchase_links image_cover=self.image_cover authors=self.authors.all editors=self.editors.all %}
+        {% include "includes/heroes/hero_publication_book.html" with title=self.title subtitle=self.subtitle purchase_links=self.book_purchase_links image_cover=self.image_cover authors=self.authors.all author_count=self.author_count editors=self.editors.all editor_count=self.editor_count %}
       {% else %}
         {% include "includes/heroes/hero_publication.html" with title=self.title subtitle=self.subtitle download=self.pdf_downloads %}
       {% endif %}
@@ -186,10 +186,10 @@
       </section>
     {% endif %}
 
-    {% if self.authors|length > 0 %}
+    {% if self.author_count > 0 %}
       {% include "includes/about_the_author.html" with authors=self.authors.all %}
     {% endif %}
-    {% if self.editors|length > 0 %}
+    {% if self.editor_count > 0 %}
       {% include "includes/about_the_author.html" with authors=self.editors.all title_override="About the Editor" %}
     {% endif %}
 

--- a/templates/publications/publication_page.html
+++ b/templates/publications/publication_page.html
@@ -187,10 +187,10 @@
     {% endif %}
 
     {% if self.author_count > 0 %}
-      {% include "includes/about_the_author.html" with authors=self.authors.all %}
+      {% include "includes/about_the_author.html" with authors=self.authors.all author_count=self.author_count %}
     {% endif %}
     {% if self.editor_count > 0 %}
-      {% include "includes/about_the_author.html" with authors=self.editors.all title_override="About the Editor" %}
+      {% include "includes/about_the_author.html" with authors=self.editors.all editor_count=self.editor_count title_override="About the Editor" %}
     {% endif %}
 
     {% if self.recommended_content %}

--- a/templates/themes/cyber_series/article_page.html
+++ b/templates/themes/cyber_series/article_page.html
@@ -97,7 +97,7 @@
       {% include 'includes/disclaimer.html' %}
 
       {% if self.is_opinion and self.author_count > 0 %}
-        {% include "includes/about_the_author.html" with authors=self.authors.all %}
+        {% include "includes/about_the_author.html" with authors=self.authors.all author_count=self.author_count %}
       {% endif %}
   </section>
 {% endblock %}


### PR DESCRIPTION
We can query the number of authors multiple times for a single request. This changes that to use a cached property instead.