### PR TITLE
CIGI-578: Use li instead of div for event hero speakers list

### DIFF
--- a/templates/includes/heroes/hero_event.html
+++ b/templates/includes/heroes/hero_event.html
@@ -29,9 +29,9 @@
             <ul class="custom-text-list">
               {% for item in authors %}
                 {% if item.hide_link %}
-                  <div class="block-speaker">{{ item.author.title }}</div>
+                  <li class="block-speaker">{{ item.author.title }}</li>
                 {% else %}
-                  <div class="block-speaker"><a href="{% pageurl item.author %}">{{ item.author.title }}</a></div>
+                  <li class="block-speaker"><a href="{% pageurl item.author %}">{{ item.author.title }}</a></li>
                 {% endif %}
               {% endfor %}
             </ul>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#578
- this spaces out the speakers slightly

![image](https://user-images.githubusercontent.com/40705848/116498370-96d44380-a877-11eb-9789-185a2a98ea46.png)
