### PR TITLE
Remove nginx Cache-Control headers

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -44,7 +44,6 @@ http {
 		<% end %>
 
 		location / {
-			add_header Cache-Control "public, max-age=1800";
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
 			proxy_set_header Authorization "";
@@ -54,7 +53,6 @@ http {
 
 		<% if ENV['STATIC_PROXY'] %>
 			location /static/ {
-				add_header Cache-Control "public, max-age=31536000";
 				proxy_pass http://<%= ENV['STATIC_PROXY'] %>/static/;
 			}
 		<% end %>


### PR DESCRIPTION
This header is overwritten by Cloudflare now, so we don't need them in our nginx config.