### PR TITLE
Add session engine back to config

### DIFF
--- a/cigionline/settings/base.py
+++ b/cigionline/settings/base.py
@@ -206,6 +206,7 @@ WAGTAILSEARCH_BACKENDS = {
     },
 }
 
+SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
Getting a CSRF verification failed error when logging in to admin. I think it's because I removed the session config in #1333 