### PR TITLE
Adding promoted search results by search terms

### DIFF
--- a/annual_reports/models.py
+++ b/annual_reports/models.py
@@ -49,7 +49,7 @@ class AnnualReportListPage(BasicPageAbstract, Page):
     settings_panels = Page.settings_panels + [
         BasicPageAbstract.submenu_panel,
     ]
-    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields + SearchablePageAbstract.search_fields
 
     class Meta:
         verbose_name = 'Annual Report List Page'
@@ -128,6 +128,9 @@ class AnnualReportPage(FeatureablePageAbstract, Page, SearchablePageAbstract):
         FeatureablePageAbstract.feature_panel,
         SearchablePageAbstract.search_panel,
     ]
+
+    search_fields = Page.search_fields + SearchablePageAbstract.search_fields
+
     parent_page_types = ['annual_reports.AnnualReportListPage']
     subpage_types = []
     templates = 'annual_reports/annual_report_page.html'

--- a/careers/models.py
+++ b/careers/models.py
@@ -104,6 +104,8 @@ class JobPostingPage(
         SearchablePageAbstract.search_panel,
     ]
 
+    search_fields = Page.search_fields + SearchablePageAbstract.search_fields
+
     parent_page_types = ['careers.JobPostingListPage']
     subpage_types = []
     templates = 'careers/job_posting_page.html'

--- a/cigionline/static/css/components/SearchResultListing.scss
+++ b/cigionline/static/css/components/SearchResultListing.scss
@@ -52,6 +52,11 @@ article {
         @include link($color: $black, $hover-color: $cigi-primary-colour);
         font-size: 1.0625em;
         margin-bottom: 0.25em;
+
+        .elevate-bookmark {
+            margin-left: 5px;
+            font-size: 15px;
+        }
       }
     }
   }

--- a/cigionline/static/js/components/SearchResultListing.js
+++ b/cigionline/static/js/components/SearchResultListing.js
@@ -46,7 +46,10 @@ function SearchResultListing(props) {
           ))}
         </ul>
         <h2 className="search-result-title">
-          <a href={row.url}>{row.title}</a>
+          <a href={row.url}>
+            {row.title}
+            {row.elevated && <i className="fal fa-bookmark elevate-bookmark" />}
+          </a>
         </h2>
         {row.publishing_date && (
           <div className="search-result-meta">

--- a/core/models.py
+++ b/core/models.py
@@ -215,6 +215,10 @@ class SearchablePageAbstract(models.Model):
         classname='collapsible collapsed',
     )
 
+    search_fields = [
+        index.SearchField('search_terms'),
+    ]
+
     class Meta:
         abstract = True
 
@@ -440,7 +444,7 @@ class ContentPage(Page, SearchablePageAbstract):
         FieldPanel('topics'),
     ]
 
-    search_fields = Page.search_fields + [
+    search_fields = Page.search_fields + SearchablePageAbstract.search_fields + [
         index.FilterField('author_ids'),
         index.SearchField('author_names'),
         index.FilterField('contenttype'),
@@ -588,7 +592,7 @@ class BasicPage(
         ThemeablePageAbstract.theme_panel,
     ]
 
-    search_fields = Page.search_fields + BasicPageAbstract.search_fields
+    search_fields = Page.search_fields + BasicPageAbstract.search_fields + SearchablePageAbstract.search_fields
 
     parent_page_types = ['careers.JobPostingListPage', 'core.BasicPage', 'home.HomePage']
     subpage_types = [

--- a/people/models.py
+++ b/people/models.py
@@ -387,7 +387,8 @@ class PersonPage(
             index.FilterField('last_name_lowercase'),
             ParentalManyToManyFilterFieldName('person_types'),
             ParentalManyToManyFilterField('topics'),
-        ]
+        ] \
+        + SearchablePageAbstract.search_fields
 
     parent_page_types = ['people.PeoplePage']
     subpage_types = []

--- a/search/views.py
+++ b/search/views.py
@@ -58,6 +58,7 @@ def search_api(request):
     for page in pages[offset:offsetLimit]:
         item = {
             'highlights': page._highlights,
+            'elevated': page._elevated,
             'id': page.id,
             'title': page.title,
             'url': page.get_url(request),


### PR DESCRIPTION
This solution boosts the score of results containing the search phrase in the `search_terms` column. I've also added highlighting to the `search_terms` field to detect if a match has occurred there. Each result is then properly marked as elevated or not.

Added some `search_fields` where they were missing so that indexing of `search_terms` is executed.