### PR TITLE
CIGI-584: Styling fixes part 1

### DIFF
--- a/cigionline/static/css/includes/_top_bar.scss
+++ b/cigionline/static/css/includes/_top_bar.scss
@@ -87,6 +87,7 @@ header {
       display: flex;
 
       ul {
+        align-items: center;
         display: flex;
         list-style: none;
         margin: 0;
@@ -94,7 +95,6 @@ header {
         a,
         button {
           color: $white;
-          display: block;
           font-size: 0.8125rem;
           padding: 1.9em 0.9em;
 
@@ -117,7 +117,7 @@ header {
         }
 
         .overlay-controls {
-          display: inline-block;
+          display: flex;
 
           &.menu-break {
             margin-left: 1.5em;

--- a/cigionline/static/css/streams/_inline_video_block.scss
+++ b/cigionline/static/css/streams/_inline_video_block.scss
@@ -1,6 +1,7 @@
 .stream-block-inline-video {
   @include video-aspect-ratio(4, 3);
-  margin: 2em 0;
+  margin-bottom: 2em;
+  margin-top: 2em;
 
   .stream-block-inline-video-content {
     @include hover-darken;

--- a/cigionline/static/pages/article_landing_page/css/article_landing_page.scss
+++ b/cigionline/static/pages/article_landing_page/css/article_landing_page.scss
@@ -69,7 +69,10 @@ section {
 
     .contributors {
       @include link($color: $black, $hover-color: $cigi-primary-colour);
-      column-count: 4;
+      @include media-breakpoint-up(sm) {
+        column-count: 4;
+      }
+      column-count: 3;
 
       li {
         list-style: none;

--- a/cigionline/static/themes/ai_series/css/_ai_series_article.scss
+++ b/cigionline/static/themes/ai_series/css/_ai_series_article.scss
@@ -120,9 +120,6 @@
   }
 
   .stream-block-blockquote {
-    @include media-breakpoint-up(md) {
-      max-width: 50rem;
-    }
     overflow: visible;
 
     .stream-block-blockquote-content {

--- a/cigionline/static/themes/ai_series/css/_ai_series_article.scss
+++ b/cigionline/static/themes/ai_series/css/_ai_series_article.scss
@@ -83,6 +83,24 @@
     }
   }
 
+  .article-footnotes {
+    font-size: 0.8125em;
+
+    ol {
+      line-height: 24px;
+      list-style: none;
+      margin: 0 0 1em 1em;
+
+      li {
+        &::before {
+          content: counter(list-item);
+          font-weight: 600;
+          margin-right: 0.25em;
+        }
+      }
+    }
+  }
+
   .series-blurb {
     color: $cigi-text-grey;
     margin-bottom: 2em;

--- a/streams/blocks.py
+++ b/streams/blocks.py
@@ -126,6 +126,7 @@ class BlockQuoteBlock(blocks.StructBlock, ThemeableBlock):
         'after_covid_series_opinion',
         'cyber_series_opinion',
         'health_security_series_opinion',
+        'ai_series_opinion',
     ]
 
     def get_template(self, context, *args, **kwargs):

--- a/templates/streams/chart_block.html
+++ b/templates/streams/chart_block.html
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="row d-block">
-    <div class="col col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+    <div class="col col-md-8 offset-md-2 col-lg-6 offset-lg-3">
       <div class="stream-block-chart">
         {% if self.title %}
           <h3 class="stream-block-chart-title">

--- a/templates/themes/ai_series/streams/opinion_block_quote_block.html
+++ b/templates/themes/ai_series/streams/opinion_block_quote_block.html
@@ -1,0 +1,15 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+
+<div class="container">
+  <div class="row d-block">
+    <div class="col col-lg-10 offset-lg-1">
+      <div class="stream-block-blockquote flex-row">
+        <div class="stream-block-blockquote-content{% if self.image %} has-image{% endif %}">
+          <blockquote>
+            {{ self.quote }}
+          </blockquote>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#584

- AI series footnotes styling /articles/international-legal-regulation-autonomous-technologies
- AI series block quote should be wider than other body blocks /articles/renewing-multilateral-governance-age-ai/
- Chart block should be narrower than other body blocks /articles/renewing-multilateral-governance-age-ai/
- Inline video block not centered /articles/strengthening-planetary-protection-policies-second-space-age/
- Vertically centre menu buttons in top bar
- Opinion series sliders authors should have less columns at smaller screen sizes /opinions
