### PR TITLE
Fix duplicate ids in search listing for elevated results

### DIFF
--- a/cigionline/static/js/components/SearchTable.js
+++ b/cigionline/static/js/components/SearchTable.js
@@ -458,7 +458,7 @@ class SearchTable extends React.Component {
                   ? (
                     <div className={[...containerClass, 'search-results', loading && 'loading'].join(' ')}>
                       {rows.map((row) => (
-                        <RowComponent key={row.id} row={row} />
+                        <RowComponent key={`${row.id}-${row.elevated}`} row={row} />
                       ))}
                     </div>
                   ) : (
@@ -474,7 +474,7 @@ class SearchTable extends React.Component {
                       </thead>
                       <tbody>
                         {rows.map((row) => (
-                          <RowComponent key={row.id} row={row} />
+                          <RowComponent key={`${row.id}-${row.elevated}`} row={row} />
                         ))}
                       </tbody>
                     </table>


### PR DESCRIPTION
Elevated results could also appear in the regular search results, so the key that was just based on the page id was being duplicated. React was then displaying an error for the duplicate key and the elevated search result remained on subsequent searches.