### PR TITLE
Fix generate expert image renditions

### DIFF
--- a/people/management/commands/generate_person_image_renditions.py
+++ b/people/management/commands/generate_person_image_renditions.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from django.core.management.base import BaseCommand
+from django.db.models import Q
 from people.models import PersonPage
 
 
@@ -9,17 +10,19 @@ class Command(BaseCommand):
 
         print(f'Starting... {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')
 
-        person_count = PersonPage.objects.live().count()
+        person_count = PersonPage.objects.live().filter(Q(image_media__isnull=False) | Q(image_square__isnull=False)).count()
         if person_count > 1000:
             person_count = 1000
         print(f'Generating image renditions for {person_count} people')
         for i in range((person_count // batch_limit) + 1):
-            people = PersonPage.objects.live().order_by('-id')[i * batch_limit:(i * batch_limit) + batch_limit]
+            people = PersonPage.objects.live().filter(Q(image_media__isnull=False) | Q(image_square__isnull=False)).order_by('-id')[i * batch_limit:(i * batch_limit) + batch_limit]
             for person in people:
                 print(f'Person {person.id}: Starting')
                 if person.image_media:
                     print(f'Person {person.id}: Generating og image from image_media')
                     person.image_media.get_rendition('fill-1600x900')
+                    print(f'Person {person.id}: Generating high res image from image_media')
+                    person.image_media.get_rendition('original')
                 if person.image_square:
                     print(f'Person {person.id}: Generating square image for expert page')
                     person.image_square.get_rendition('fill-200x200')


### PR DESCRIPTION
The query was hitting the limit of 1000 people and wasn't generating images for older experts. Updated the query to filter people with images.

I also added the original image rendition for the high res image on the expert page.