### PR TITLE
Add expires to privacy notice cookie

### DIFF
--- a/cigionline/static/js/components/CookieConsent.js
+++ b/cigionline/static/js/components/CookieConsent.js
@@ -14,7 +14,7 @@ class CookieConsent extends React.Component {
   }
 
   handleConsent() {
-    document.cookie = 'cigionline.accept.privacy.notice=1';
+    document.cookie = `cigionline.accept.privacy.notice=1; expires=${new Date(2147483647 * 1000).toUTCString()}`;
     this.setState({
       consentClicked: true,
     });


### PR DESCRIPTION
Add an expires at to the privacy notice cookie. From [the MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie):
```
If neither expires nor max-age specified it will expire at the end of session.
```