### PR TITLE
CIGI-595: Multimedia fixes

### DIFF
--- a/cigionline/settings/base.py
+++ b/cigionline/settings/base.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     'compressor',
     'contact',
     'core',
+    'embeds',
     'events',
     'home',
     'images',
@@ -161,6 +162,7 @@ simplecast_provider = {
 }
 
 WAGTAILEMBEDS_FINDERS = [
+    {'class': 'embeds.finders.oembed.YouTubeOEmbedFinder'},
     {'class': 'wagtail.embeds.finders.oembed', 'providers': [simplecast_provider], },
     {'class': 'wagtail.embeds.finders.oembed', },
 ]

--- a/cigionline/static/css/includes/_hero_multimedia.scss
+++ b/cigionline/static/css/includes/_hero_multimedia.scss
@@ -71,6 +71,7 @@
     &.sticky-video {
       max-width: 100%;
       padding: 0;
+      z-index: 20;
 
       .mm-video-header {
         animation: slide-down 0.3s;

--- a/cigionline/static/js/components/MultimediaListing.js
+++ b/cigionline/static/js/components/MultimediaListing.js
@@ -12,7 +12,12 @@ function MultimediaListing(props) {
       <a href={row.url} className="multimedia-card-image">
         <div className="img-wrapper" style={{ backgroundImage: `url(${row.image_hero_url})` }} />
         <div className="multimedia-image-type">
-          <i className="fas fa-play" />
+          {row.contentsubtype === 'Video' && (
+            <i className="fas fa-play" />
+          )}
+          {row.contentsubtype === 'Audio' && (
+            <i className="fas fa-volume-up" />
+          )}
         </div>
       </a>
       <ul className="custom-text-list multimedia-card-topic-list">
@@ -57,6 +62,7 @@ MultimediaListing.propTypes = {
       type: PropTypes.string,
       value: PropTypes.any,
     })),
+    contentsubtype: PropTypes.string,
     id: PropTypes.number,
     image_hero_url: PropTypes.string,
     publishing_date: PropTypes.string,

--- a/cigionline/static/js/components/MultimediaListing.js
+++ b/cigionline/static/js/components/MultimediaListing.js
@@ -12,11 +12,10 @@ function MultimediaListing(props) {
       <a href={row.url} className="multimedia-card-image">
         <div className="img-wrapper" style={{ backgroundImage: `url(${row.image_hero_url})` }} />
         <div className="multimedia-image-type">
-          {row.contentsubtype === 'Video' && (
-            <i className="fas fa-play" />
-          )}
-          {row.contentsubtype === 'Audio' && (
+          {row.contentsubtype === 'Audio' ? (
             <i className="fas fa-volume-up" />
+          ) : (
+            <i className="fas fa-play" />
           )}
         </div>
       </a>

--- a/cigionline/static/pages/multimedia_list_page/index.js
+++ b/cigionline/static/pages/multimedia_list_page/index.js
@@ -13,6 +13,7 @@ ReactDOM.render(
     limit={18}
     fields={[
       'authors',
+      'contentsubtype',
       'image_hero_url',
       'publishing_date',
       'topics',

--- a/embeds/finders/oembed.py
+++ b/embeds/finders/oembed.py
@@ -3,7 +3,6 @@ from django.core.exceptions import ImproperlyConfigured
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from wagtail.embeds.finders.oembed import OEmbedFinder
 from wagtail.embeds.oembed_providers import youtube
-import re
 
 
 class YouTubeOEmbedFinder(OEmbedFinder):

--- a/embeds/finders/oembed.py
+++ b/embeds/finders/oembed.py
@@ -1,0 +1,36 @@
+from bs4 import BeautifulSoup
+from django.core.exceptions import ImproperlyConfigured
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from wagtail.embeds.finders.oembed import OEmbedFinder
+from wagtail.embeds.oembed_providers import youtube
+import re
+
+
+class YouTubeOEmbedFinder(OEmbedFinder):
+    def __init__(self, providers=None, options=None):
+        if providers is None:
+            providers = [youtube]
+
+        if providers != [youtube]:
+            raise ImproperlyConfigured(
+                'The YouTubeOEmbedFinder should only work with the youtube provider'
+            )
+
+        super().__init__(providers=providers, options=options)
+
+    def find_embed(self, url, max_width=None):
+        embed = super().find_embed(url, max_width)
+
+        soup = BeautifulSoup(embed['html'], 'html.parser')
+        iframe_url = soup.find('iframe').attrs['src']
+        scheme, netloc, path, params, query, fragment = urlparse(iframe_url)
+
+        querydict = parse_qs(query)
+        querydict['rel'] = 0
+        query = urlencode(querydict, doseq=1)
+
+        iframe_url = urlunparse((scheme, netloc, path, params, query, fragment))
+        soup.find('iframe').attrs['src'] = iframe_url
+        embed['html'] = str(soup)
+
+        return embed


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#595

- Use audio icon for audio contentsubtype in multimedia landing page listing
![image](https://user-images.githubusercontent.com/40705848/118538043-aed31080-b71b-11eb-904b-bf2fd88baf63.png)

- Added custom oembed finder to add rel=0 param. This limits recommended items to those from our youtube channel
![image](https://user-images.githubusercontent.com/40705848/118538002-a084f480-b71b-11eb-97e5-06239bfdd59e.png)

- Increased sticky video player z-index so it covers menu bar
![image](https://user-images.githubusercontent.com/40705848/118537959-94009c00-b71b-11eb-85f3-f9307bb7029c.png)

