### PR TITLE
CIGI-605: Add complete url for newsletter advertisement block images

### DIFF
--- a/streams/blocks.py
+++ b/streams/blocks.py
@@ -723,7 +723,7 @@ class NewsletterBlock(blocks.StructBlock):
             context['cta_text'] = self.cta_text(value.get('cta')).upper()
 
         if value.get('image'):
-            context['image_url'] = value.get("image").get_rendition("fill-600x238").file.name
+            context['image_url'] = f'{context["page"].get_site().root_url}{settings.STATIC_URL}{value.get("image").get_rendition("fill-600x238").file.name}'
 
         if value.get('content'):
             content_page = value.get('content').specific


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#605

- Fixed issue where newsletter advertisement block image doesn't use full image url