### PR TITLE
Revert "Bump astroid from 2.5.6 to 2.6.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 anyascii==0.2.0
 asgiref==3.3.4
-astroid==2.6.2
+astroid==2.5.6
 beautifulsoup4==4.9.3
 boto3==1.17.68
 botocore==1.20.68


### PR DESCRIPTION
Reverts CIGIHub/cigionline#1624

pylint 2.6.0 requires astroid<=2.5, >=2.4.0