### PR TITLE
CIGI-630: Event Timezone Set Default Label to Eastern

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -219,6 +219,8 @@ class EventPage(
 
     @property
     def time_zone_label(self):
+        # timezone could have been assigned in freeform (previous version), or from a list of options (post change)
+        # if it's from a list of options post change:
         if self.time_zone in self.EventTimeZones.values:
             '''
             timezone name set to short code based on self.time_zone value; in case no name is available,
@@ -230,8 +232,15 @@ class EventPage(
                         f'{datetime.datetime.now(pytz.timezone(self.time_zone)).strftime("%Z")} ')
             offset = datetime.datetime.now(pytz.timezone(self.time_zone)).strftime('%z')
             # return string format: "TZ (OFFSET)"" eg. "EDT (UTC-04:00)"
-            return f'{tz}(UTC{offset[:3]}:{offset[3:]})'
-        return self.time_zone
+            label = f'{tz}(UTC{offset[:3]}:{offset[3:]})'
+        # if it's not assigned: default to eastern
+        elif not self.time_zone:
+            tz_and_offset = datetime.datetime.now(pytz.timezone('America/Toronto')).strftime('%Z%z')
+            label = f'{tz_and_offset[:3]} (UTC{tz_and_offset[3:6]}:{tz_and_offset[6:]})'
+        # if it was assigned in freeform - preserve
+        else:
+            label = self.time_zone
+        return label
 
     content_panels = [
         BasicPageAbstract.title_panel,


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#630
- events without timezone are already treated as Eastern time in the backend; adjust label to reflect this in the frontend
- 3 scenarios: 
1) if timezone was assigned from a list of options - show corresponding label (same as master)
2) if timezone was assigned from freeform input - label show freeform input (same as master)
3) if timezone was not assigned - label show eastern time (update)

#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [ ] Have you reviewed your own code changes?
- [ ] Has the issue owner reviewed your changes?
- [ ] Have you given the PR a descriptive title?
- [ ] Have you described your changes above? Always include screenshots if applicable.
- [ ] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
