### PR TITLE
CIGI-633: Make people on staff list unclickable if they don"t have bio

### DIFF
--- a/cigionline/static/js/components/StaffListing.js
+++ b/cigionline/static/js/components/StaffListing.js
@@ -8,7 +8,11 @@ function StaffListing(props) {
   return (
     <article className="staff-listing">
       <div className="name-container">
-        <a className="name" href={row.url}>{row.title}</a>
+        {row.has_bio ? (
+          <a className="name" href={row.url}>{row.title}</a>
+        ) : (
+          <div className="name">{row.title}</div>
+        )}
         <div className="position">{row.position}</div>
       </div>
       <div className="contact-container">
@@ -32,6 +36,7 @@ function StaffListing(props) {
 StaffListing.propTypes = {
   row: PropTypes.shape({
     email: PropTypes.string,
+    has_bio: PropTypes.bool,
     phone_number: PropTypes.string,
     position: PropTypes.string,
     title: PropTypes.string.isRequired,

--- a/people/views.py
+++ b/people/views.py
@@ -91,5 +91,6 @@ def all_staff(request):
             'position': person.position,
             'title': person.title,
             'url': person.get_url(request),
+            'has_bio': False if not person.body else True,
         } for person in staff[:50]]
     })


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#633
- Added property to staff list api call and don't render link if a person's bio is empty

#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
