### PR TITLE
CIGI-628: added youtube icon to newsletter template footer

### DIFF
--- a/templates/newsletters/newsletter_html.html
+++ b/templates/newsletters/newsletter_html.html
@@ -304,6 +304,8 @@
                                     href="https://twitter.com/cigionline?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
                                       src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/a85581e0-e251-4cb0-bcde-0fd42ee8dc26.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
                                     href="https://www.linkedin.com/company/cigionline?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
+                                      src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/010f251d-7354-41cd-9e64-fc4953dfc461.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
+                                    href="https://www.youtube.com/user/cigivideos?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
                                       src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/010f251d-7354-41cd-9e64-fc4953dfc461.png" /></a>
                                 </div>
                               </td>

--- a/templates/newsletters/newsletter_html.html
+++ b/templates/newsletters/newsletter_html.html
@@ -306,7 +306,7 @@
                                     href="https://www.linkedin.com/company/cigionline?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
                                       src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/010f251d-7354-41cd-9e64-fc4953dfc461.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
                                     href="https://www.youtube.com/user/cigivideos?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
-                                      src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/010f251d-7354-41cd-9e64-fc4953dfc461.png" /></a>
+                                      src="https://mcusercontent.com/3cafbe8a8401ae9ed275d2f75/images/d0f7cebc-8ddb-596e-320c-cf8cff972c3a.png" /></a>
                                 </div>
                               </td>
                             </tr>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#628

Currently newsletter footer only have icons and links to facebook/twitter/linkedin; this PR adds youtube next to them.

#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [ ] Have you reviewed your own code changes?
- [ ] Has the issue owner reviewed your changes?
- [ ] Have you given the PR a descriptive title?
- [ ] Have you described your changes above? Always include screenshots if applicable.
- [ ] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
