### PR TITLE
CIGI-632b: bug fix for when a link doesnt have href

### DIFF
--- a/streams/blocks.py
+++ b/streams/blocks.py
@@ -837,7 +837,10 @@ class NewsletterBlock(blocks.StructBlock):
             text_soup = BeautifulSoup(context['text'].source, 'html.parser')
             for link in text_soup.findAll('a'):
                 link['style'] = 'text-decoration: none; color: #ee1558;'
-                link['href'] = in_line_tracking(link['href'], context['page'].title)
+                try:
+                    link['href'] = in_line_tracking(link['href'], context['page'].title)
+                except KeyError:
+                    pass
 
             context['text'].source = str(text_soup)
 


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#632

In-line urls are tacked on tracking to their href; some [newsletters](https://www.cigionline.org/newsletters/our-misrepresented-digital-rights/) do not have href and is throwing an error.
This wraps the process in a try/except to prevent this error.

#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
