### PR TITLE
CIGI-638: move the addition of tracking url to html_string

### DIFF
--- a/newsletters/models.py
+++ b/newsletters/models.py
@@ -88,7 +88,7 @@ class NewsletterPage(Page):
         for link in text_soup.findAll('a'):
             try:
                 link['href'] = in_line_tracking(link['href'], title)
-            except TypeError:
+            except KeyError:
                 pass
 
         return str(text_soup)

--- a/newsletters/models.py
+++ b/newsletters/models.py
@@ -84,10 +84,9 @@ class NewsletterPage(Page):
                                                    {'self': self, 'page': self, 'is_html_string': True}),
                                   'html.parser')
 
-        title = self.title
         for link in text_soup.findAll('a'):
             try:
-                link['href'] = in_line_tracking(link['href'], title)
+                link['href'] = in_line_tracking(link['href'], self.title)
             except KeyError:
                 pass
 

--- a/newsletters/models.py
+++ b/newsletters/models.py
@@ -8,6 +8,8 @@ from wagtail.admin.edit_handlers import MultiFieldPanel, StreamFieldPanel
 from wagtail.core.fields import StreamField
 from wagtail.core.models import Page
 from wagtail.documents.edit_handlers import DocumentChooserPanel
+from bs4 import BeautifulSoup
+from django.utils.text import slugify
 
 
 class NewsletterListPage(BasicPageAbstract, Page):
@@ -71,7 +73,25 @@ class NewsletterPage(Page):
     ]
 
     def html_string(self):
-        return render_to_string('newsletters/newsletter_html.html', {'self': self, 'page': self, 'is_html_string': True})
+        def in_line_tracking(href, title):
+            tracking = f'utm_source=cigi_newsletter&utm_medium=email&utm_campaign={slugify(title)}'
+            if '?' in href:
+                return f'{href}&{tracking}'
+            else:
+                return f'{href}?{tracking}'
+
+        text_soup = BeautifulSoup(render_to_string('newsletters/newsletter_html.html',
+                                                   {'self': self, 'page': self, 'is_html_string': True}),
+                                  'html.parser')
+
+        title = self.title
+        for link in text_soup.findAll('a'):
+            try:
+                link['href'] = in_line_tracking(link['href'], title)
+            except TypeError:
+                pass
+
+        return str(text_soup)
 
     parent_page_types = ['newsletters.NewsletterListPage']
     subpage_types = []

--- a/streams/blocks.py
+++ b/streams/blocks.py
@@ -11,7 +11,6 @@ from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.images.blocks import ImageChooserBlock
 from wagtailmedia.blocks import AbstractMediaChooserBlock
 import pytz
-from django.utils.text import slugify
 
 
 class ThemeableBlock:
@@ -826,18 +825,10 @@ class NewsletterBlock(blocks.StructBlock):
 
                     context['text'].source = str(soup)
 
-        def in_line_tracking(href, title):
-            tracking = f'utm_source=cigi_newsletter&utm_medium=email&utm_campaign={slugify(title)}'
-            if '?' in href:
-                return f'{href}&{tracking}'
-            else:
-                return f'{href}?{tracking}'
-
         if context.get('text'):
             text_soup = BeautifulSoup(context['text'].source, 'html.parser')
             for link in text_soup.findAll('a'):
                 link['style'] = 'text-decoration: none; color: #ee1558;'
-                link['href'] = in_line_tracking(link['href'], context['page'].title)
 
             context['text'].source = str(text_soup)
 

--- a/templates/newsletters/newsletter_html.html
+++ b/templates/newsletters/newsletter_html.html
@@ -172,7 +172,7 @@
                       <div
                         style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
                         <p class="cigi-logo" style="margin:0;Margin:0;padding:0;line-height:1;">
-                          <a href="https://www.cigionline.org?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}">
+                          <a href="https://www.cigionline.org">
                             <img
                               src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/97eb05b4-24e5-4fc4-8c85-89faea886811.png"
                               width="150" alt="Centre for International Governance Innovation" />
@@ -299,13 +299,13 @@
                               <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
                                 <div
                                   style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:1;text-align:center;color:#696969;">
-                                  <a href="https://www.facebook.com/cigionline?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
+                                  <a href="https://www.facebook.com/cigionline"><img width="14"
                                       src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/0cfa05ea-040f-4f73-848a-9f12132fd52c.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
-                                    href="https://twitter.com/cigionline?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
+                                    href="https://twitter.com/cigionline"><img width="14"
                                       src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/a85581e0-e251-4cb0-bcde-0fd42ee8dc26.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
-                                    href="https://www.linkedin.com/company/cigionline?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
+                                    href="https://www.linkedin.com/company/cigionline"><img width="14"
                                       src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/010f251d-7354-41cd-9e64-fc4953dfc461.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
-                                    href="https://www.youtube.com/user/cigivideos?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}"><img width="14"
+                                    href="https://www.youtube.com/user/cigivideos"><img width="14"
                                       src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/d0f7cebc-8ddb-596e-320c-cf8cff972c3a.png" /></a>
                                 </div>
                               </td>
@@ -355,7 +355,7 @@
                                 style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                                 <div
                                   style="font-family:futura-pt, Arial, sans-serif;font-size:14px;font-style:normal;font-weight:400;line-height:14px;text-align:center;color:#ffffff;">
-                                  <a href="*|ARCHIVE|*?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}" style="color:#ffffff;text-decoration:none;">View in a
+                                  <a href="*|ARCHIVE|*" style="color:#ffffff;text-decoration:none;">View in a
                                     browser</a>
                                 </div>
                               </td>
@@ -421,7 +421,7 @@
                     <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div
                         style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:center;color:#696969;">
-                        <a href="*|UNSUB|*?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{self.title|slugify}}" style="color:#696969;text-decoration:none;">Click here to unsubscribe</a>
+                        <a href="*|UNSUB|*" style="color:#696969;text-decoration:none;">Click here to unsubscribe</a>
                       </div>
                     </td>
                   </tr>

--- a/templates/streams/newsletter/advertisement_block.html
+++ b/templates/streams/newsletter/advertisement_block.html
@@ -29,7 +29,7 @@
                       <tbody>
                         <tr>
                           <td style="width:550px;">
-                            <a href="{{ url|slice:':-1' }}?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{page.title|slugify}}" target="_blank">
+                            <a href="{{ url|slice:':-1' }}" target="_blank">
                               <img alt="{{ image.caption }}" height="auto"
                                 src="{{ image_url }}"
                                 style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
@@ -84,7 +84,7 @@
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                   <div
                     style="font-family:futura-pt, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
-                    <a href="{{ url|slice:':-1' }}?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{page.title|slugify}}" style="color: #000000; text-decoration: none;">{{ title }}</a>
+                    <a href="{{ url|slice:':-1' }}" style="color: #000000; text-decoration: none;">{{ title }}</a>
                   </div>
                 </td>
               </tr>
@@ -115,7 +115,7 @@
                       <td align="center" bgcolor="transparent" role="presentation"
                         style="border:1px solid #e71b3e;border-radius:2px;cursor:auto;font-style:normal;mso-padding-alt:8px 16px;background:transparent;"
                         valign="middle">
-                        <a href="{{ url|slice:':-1' }}?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{page.title|slugify}}"
+                        <a href="{{ url|slice:':-1' }}"
                           style="display:inline-block;background:transparent;color:#e71b3e;font-family:futura-pt, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
                           target="_blank">
                           {% if cta_image_link %}<img src="{{ cta_image_link }}" width="13" height="13"

--- a/templates/streams/newsletter/content_block.html
+++ b/templates/streams/newsletter/content_block.html
@@ -81,7 +81,7 @@
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                   <div
                     style="font-family:futura-pt, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
-                    <a href="{{ url|slice:':-1' }}?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{page.title|slugify}}" style="color: #000000; text-decoration: none;">
+                    <a href="{{ url|slice:':-1' }}" style="color: #000000; text-decoration: none;">
                       {{ title }}
                     </a>
                   </div>
@@ -115,7 +115,7 @@
                       <td align="center" bgcolor="transparent" role="presentation"
                         style="border:1px solid #e71b3e;border-radius:2px;cursor:auto;font-style:normal;mso-padding-alt:8px 16px;background:transparent;"
                         valign="middle">
-                        <a href="{{ url|slice:':-1' }}?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{page.title|slugify}}"
+                        <a href="{{ url|slice:':-1' }}"
                           style="display:inline-block;background:transparent;color:#e71b3e;font-family:futura-pt, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
                           target="_blank">
                           {% if cta_image_link %}<img src="{{ cta_image_link }}" width="13" height="13"

--- a/templates/streams/newsletter/featured_content_block.html
+++ b/templates/streams/newsletter/featured_content_block.html
@@ -32,7 +32,7 @@
                     <tbody>
                       <tr>
                         <td style="width:550px;">
-                          <a href="{{ url|slice:':-1' }}?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{page.title|slugify}}" target="_blank">
+                          <a href="{{ url|slice:':-1' }}" target="_blank">
                             <img alt="{{ image_alt }}" height="auto" src="{{ image_url }}"
                               style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;"
                               width="550" />
@@ -85,7 +85,7 @@
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                   <div
                     style="font-family:futura-pt, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
-                    <a href="{{ url|slice:':-1' }}?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{page.title|slugify}}" style="color: #000000; text-decoration: none;">{{ title }}</a>
+                    <a href="{{ url|slice:':-1' }}" style="color: #000000; text-decoration: none;">{{ title }}</a>
                   </div>
                 </td>
               </tr>
@@ -116,7 +116,7 @@
                       <td align="center" bgcolor="transparent" role="presentation"
                         style="border:1px solid #e71b3e;border-radius:2px;cursor:auto;font-style:normal;mso-padding-alt:8px 16px;background:transparent;"
                         valign="middle">
-                        <a href="{{ url|slice:':-1' }}?utm_source=cigi_newsletter&utm_medium=email&utm_campaign={{page.title|slugify}}"
+                        <a href="{{ url|slice:':-1' }}"
                           style="display:inline-block;background:transparent;color:#e71b3e;font-family:futura-pt, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
                           target="_blank">
                           {% if cta_image_link %}<img src="{{ cta_image_link }}" width="13" height="13"


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#638
- add tracking url to every href in newsletter html_string
- remove the addition of tracking url from various other places (blocks)
- all links in the html_string, including in-line url and in-line reference to other pages in cigionline, should now have GA tracking

#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
