### PR TITLE
CIGI-641: change futura-pt to Helvetica in newsletter templates

### DIFF
--- a/templates/newsletters/newsletter_html.html
+++ b/templates/newsletters/newsletter_html.html
@@ -170,7 +170,7 @@
                   <tr>
                     <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div
-                        style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
+                        style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
                         <p class="cigi-logo" style="margin:0;Margin:0;padding:0;line-height:1;">
                           <a href="https://www.cigionline.org">
                             <img
@@ -194,7 +194,7 @@
                   <tr>
                     <td align="right" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                       <div
-                        style="font-family:futura-pt, Arial, sans-serif;font-size:14px;font-style:normal;font-weight:400;line-height:21px;text-align:right;color:#ffffff;">
+                        style="font-family:Helvetica, Arial, sans-serif;font-size:14px;font-style:normal;font-weight:400;line-height:21px;text-align:right;color:#ffffff;">
                         <p class="cigi-slogan" style="margin:0;Margin:0;padding:0;">Influential research. Trusted
                           analysis.</p>
                       </div>
@@ -252,7 +252,7 @@
                               <td align="center"
                                 style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                                 <div
-                                  style="font-family:futura-pt, Arial, sans-serif;font-size:14px;font-style:normal;font-weight:400;line-height:14px;text-align:center;color:#ffffff;">
+                                  style="font-family:Helvetica, Arial, sans-serif;font-size:14px;font-style:normal;font-weight:400;line-height:14px;text-align:center;color:#ffffff;">
                                   Follow us</div>
                               </td>
                             </tr>
@@ -298,7 +298,7 @@
                             <tr>
                               <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
                                 <div
-                                  style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:1;text-align:center;color:#696969;">
+                                  style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:1;text-align:center;color:#696969;">
                                   <a href="https://www.facebook.com/cigionline"><img width="14"
                                       src="https://gallery.mailchimp.com/3cafbe8a8401ae9ed275d2f75/images/0cfa05ea-040f-4f73-848a-9f12132fd52c.png" /></a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
                                     href="https://twitter.com/cigionline"><img width="14"
@@ -354,7 +354,7 @@
                               <td align="center"
                                 style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                                 <div
-                                  style="font-family:futura-pt, Arial, sans-serif;font-size:14px;font-style:normal;font-weight:400;line-height:14px;text-align:center;color:#ffffff;">
+                                  style="font-family:Helvetica, Arial, sans-serif;font-size:14px;font-style:normal;font-weight:400;line-height:14px;text-align:center;color:#ffffff;">
                                   <a href="*|ARCHIVE|*" style="color:#ffffff;text-decoration:none;">View in a
                                     browser</a>
                                 </div>
@@ -364,7 +364,7 @@
                               <td align="center"
                                 style="font-size:0px;padding:10px 25px;padding-top:5px;word-break:break-word;">
                                 <div
-                                  style="font-family:futura-pt, Arial, sans-serif;font-size:12px;font-style:normal;font-weight:400;line-height:12px;text-align:center;color:#747474;">
+                                  style="font-family:Helvetica, Arial, sans-serif;font-size:12px;font-style:normal;font-weight:400;line-height:12px;text-align:center;color:#747474;">
                                   &copy; {% now "Y" %} Centre for International Governance Innovation</div>
                               </td>
                             </tr>
@@ -420,7 +420,7 @@
                   <tr>
                     <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                       <div
-                        style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:center;color:#696969;">
+                        style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:center;color:#696969;">
                         <a href="*|UNSUB|*" style="color:#696969;text-decoration:none;">Click here to unsubscribe</a>
                       </div>
                     </td>

--- a/templates/streams/newsletter/advertisement_block.html
+++ b/templates/streams/newsletter/advertisement_block.html
@@ -83,7 +83,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                   <div
-                    style="font-family:futura-pt, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
+                    style="font-family:Helvetica, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
                     <a href="{{ url|slice:':-1' }}" style="color: #000000; text-decoration: none;">{{ title }}</a>
                   </div>
                 </td>
@@ -91,7 +91,7 @@
               <tr class="text-block">
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   <div
-                    style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
+                    style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
                     {{ text }}</div>
                 </td>
               </tr>
@@ -116,7 +116,7 @@
                         style="border:1px solid #e71b3e;border-radius:2px;cursor:auto;font-style:normal;mso-padding-alt:8px 16px;background:transparent;"
                         valign="middle">
                         <a href="{{ url|slice:':-1' }}"
-                          style="display:inline-block;background:transparent;color:#e71b3e;font-family:futura-pt, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
+                          style="display:inline-block;background:transparent;color:#e71b3e;font-family:Helvetica, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
                           target="_blank">
                           {% if cta_image_link %}<img src="{{ cta_image_link }}" width="13" height="13"
                             style="display:inline;padding:0;vertical-align:middle;" />{% endif %}&nbsp;&nbsp;{{ cta_text }}

--- a/templates/streams/newsletter/content_block.html
+++ b/templates/streams/newsletter/content_block.html
@@ -80,7 +80,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                   <div
-                    style="font-family:futura-pt, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
+                    style="font-family:Helvetica, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
                     <a href="{{ url|slice:':-1' }}" style="color: #000000; text-decoration: none;">
                       {{ title }}
                     </a>
@@ -90,7 +90,7 @@
               <tr class="text-block">
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   <div
-                    style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
+                    style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
                     {{ text }}
                   </div>
                 </td>
@@ -116,7 +116,7 @@
                         style="border:1px solid #e71b3e;border-radius:2px;cursor:auto;font-style:normal;mso-padding-alt:8px 16px;background:transparent;"
                         valign="middle">
                         <a href="{{ url|slice:':-1' }}"
-                          style="display:inline-block;background:transparent;color:#e71b3e;font-family:futura-pt, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
+                          style="display:inline-block;background:transparent;color:#e71b3e;font-family:Helvetica, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
                           target="_blank">
                           {% if cta_image_link %}<img src="{{ cta_image_link }}" width="13" height="13"
                             style="display:inline;padding:0;vertical-align:middle;" />{% endif %}&nbsp;&nbsp;{{ cta_text }}

--- a/templates/streams/newsletter/featured_content_block.html
+++ b/templates/streams/newsletter/featured_content_block.html
@@ -84,7 +84,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                   <div
-                    style="font-family:futura-pt, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
+                    style="font-family:Helvetica, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
                     <a href="{{ url|slice:':-1' }}" style="color: #000000; text-decoration: none;">{{ title }}</a>
                   </div>
                 </td>
@@ -92,7 +92,7 @@
               <tr class="text-block">
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   <div
-                    style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
+                    style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
                     {{ text }}</div>
                 </td>
               </tr>
@@ -117,7 +117,7 @@
                         style="border:1px solid #e71b3e;border-radius:2px;cursor:auto;font-style:normal;mso-padding-alt:8px 16px;background:transparent;"
                         valign="middle">
                         <a href="{{ url|slice:':-1' }}"
-                          style="display:inline-block;background:transparent;color:#e71b3e;font-family:futura-pt, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
+                          style="display:inline-block;background:transparent;color:#e71b3e;font-family:Helvetica, Arial, sans-serif;font-size:10px;font-style:normal;font-weight:400;line-height:1;margin:0;text-decoration:none;text-transform:none;padding:8px 12px;mso-padding-alt:0px;border-radius:2px;"
                           target="_blank">
                           {% if cta_image_link %}<img src="{{ cta_image_link }}" width="13" height="13"
                             style="display:inline;padding:0;vertical-align:middle;" />{% endif %}&nbsp;&nbsp;{{ cta_text }}

--- a/templates/streams/newsletter/social_block.html
+++ b/templates/streams/newsletter/social_block.html
@@ -36,7 +36,7 @@
                           <td align="left"
                             style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
                             <div
-                              style="font-family:futura-pt, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
+                              style="font-family:Helvetica, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
                               {% if self.title %}
                                 {{self.title}}
                               {% else %}
@@ -94,7 +94,7 @@
                           <td align="left"
                             style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                             <div
-                              style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
+                              style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
                               {{text}}
                             </div>
                           </td>

--- a/templates/streams/newsletter/text_block.html
+++ b/templates/streams/newsletter/text_block.html
@@ -21,7 +21,7 @@
                 <tr>
                   <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;">
                     <div
-                      style="font-family:futura-pt, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
+                      style="font-family:Helvetica, Arial, sans-serif;font-size:21px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#000000;">
                       {{self.title}}</div>
                   </td>
                 </tr>
@@ -29,7 +29,7 @@
               <tr class="text-block">
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   <div
-                    style="font-family:futura-pt, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
+                    style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
                     {{text}}</div>
                 </td>
               </tr>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#641
This changes font-family of newsletter templates from `font-family:futura-pt, Arial, sans-serif` to `font-family:Helvetica, Arial, sans-serif`, affecting both newsletter pages as well as their html string for export.


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [x] Have you reviewed the code changes?
- [x] Have you tested the changes on Google Chrome?
- [x] Have you tested the changes on Safari?
- [x] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [x] Have you tested the changes on iOS?
- [x] Have you tested the changes on Android?
