### PR TITLE
CIGI-681: require specific person_types to show high-res

### DIFF
--- a/core/templatetags/core_tags.py
+++ b/core/templatetags/core_tags.py
@@ -25,6 +25,14 @@ def in_list(value, the_list):
     return value in the_list.split(',')
 
 
+@register.filter
+def any_in_list(values, the_list):
+    for value in values:
+        if str(value) in the_list.split(','):
+            return True
+    return False
+
+
 @register.simple_tag
 def define(value):
     return value

--- a/templates/people/person_page.html
+++ b/templates/people/person_page.html
@@ -143,7 +143,7 @@
                       </div>
                     {% endif %}
 
-                    {% if page.image_media %}
+                    {% if page.image_media and page.person_types.all|any_in_list:'Expert,Management Team,Board Member' %}
                       {% image page.image_media original as high_res %}
                       <div class="contact-item">
                         <i class="fas fa-download" aria-hidden="true"></i>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#681

- created tag to determine if any in a list of values, casted as str, belong to another provided list
- add condition to display high-res link: must be of 'Expert', 'Management Team', or 'Board Member' person_types


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
