### PR TITLE
CIGI-684: Allow multiple rows of promotion blocks on home page

### DIFF
--- a/cigionline/static/pages/home_page/css/_home_page.scss
+++ b/cigionline/static/pages/home_page/css/_home_page.scss
@@ -154,6 +154,10 @@
         }
         margin-bottom: 1em;
       }
+
+      &.promotion-block-wide {
+        flex-basis: 100%;
+      }
     }
   }
 }

--- a/cigionline/static/pages/home_page/css/_home_page.scss
+++ b/cigionline/static/pages/home_page/css/_home_page.scss
@@ -148,13 +148,13 @@
 
   .homepage-promotion-blocks {
     .homepage-promotion-block {
-      margin-bottom: 2em;
+      @include media-breakpoint-up(md) {
+        margin-bottom: 2em;
+      }
+      margin-bottom: 1em;
 
-      &:first-child {
-        @include media-breakpoint-up(md) {
-          margin-bottom: 0;
-        }
-        margin-bottom: 1em;
+      &:last-child {
+        margin-bottom: 0;
       }
 
       &.promotion-block-wide {

--- a/cigionline/static/pages/home_page/css/_home_page.scss
+++ b/cigionline/static/pages/home_page/css/_home_page.scss
@@ -148,6 +148,8 @@
 
   .homepage-promotion-blocks {
     .homepage-promotion-block {
+      margin-bottom: 2em;
+
       &:first-child {
         @include media-breakpoint-up(md) {
           margin-bottom: 0;

--- a/home/models.py
+++ b/home/models.py
@@ -71,7 +71,7 @@ class HomePage(Page):
             [
                 InlinePanel(
                     'promotion_blocks',
-                    max_num=2,
+                    max_num=4,
                     min_num=0,
                     label='Promotion Block',
                 ),
@@ -139,7 +139,7 @@ class HomePage(Page):
         promotion_blocks_list = []
         for item in self.promotion_blocks.prefetch_related(
             'promotion_block',
-        ).all()[:2]:
+        ).all():
             promotion_blocks_list.append(item.promotion_block)
         return promotion_blocks_list
 

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -76,13 +76,7 @@
       <div class="container">
         <div class="row promotion-blocks-container">
           {% for promotion_block in promotion_blocks %}
-            <div class="homepage-promotion-block 
-              {% if promotion_block.block_type == 'wide' or promotion_block.block_type == 'podcast_player' %}
-                col promotion-block-wide
-              {% else %}
-                col-md-6
-              {% endif %}
-            ">
+            <div class="homepage-promotion-block {% if promotion_block.block_type == 'wide' or promotion_block.block_type == 'podcast_player' %}col promotion-block-wide{% else %}col-md-6{% endif %}">
               {% include "includes/promotion_block.html" with promotion_block=promotion_block %}
             </div>
           {% endfor %}

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -74,11 +74,11 @@
     </section>
     <section class="homepage-promotion-blocks">
       <div class="container">
-        <div class="row">
+        <div class="row promotion-blocks-container">
           {% for promotion_block in promotion_blocks %}
             <div class="homepage-promotion-block 
               {% if promotion_block.block_type == 'wide' or promotion_block.block_type == 'podcast_player' %}
-                col
+                col promotion-block-wide
               {% else %}
                 col-md-6
               {% endif %}


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#684

- Relax block limit on home page
- Add class to make wide and podcast blocks take up entire container width
- Add margin bottom

![image](https://user-images.githubusercontent.com/40705848/144626448-3eb53f68-d07e-49c4-ad17-839b6602ef54.png)

![image](https://user-images.githubusercontent.com/40705848/144626564-4e20907d-2e27-4e68-8e6a-0177ff184121.png)


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
