### PR TITLE
CIGI-705: Fix home page ar width, and featured publications overflow

### DIFF
--- a/cigionline/static/css/includes/features/_feature_publication_teaser.scss
+++ b/cigionline/static/css/includes/features/_feature_publication_teaser.scss
@@ -2,9 +2,12 @@ article {
   &.feature-publication-teaser {
     @include media-breakpoint-up(md) {
       border: 1px solid $cigi-medium-grey;
-      height: 300px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
       margin-bottom: 0;
       max-width: 300px;
+      min-height: 300px;
       padding: 1em;
       position: relative;
       width: 100%;
@@ -23,64 +26,57 @@ article {
     margin-bottom: 1.5em;
     padding-bottom: 1.5em;
 
-    .feature-publication-teaser-content {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-      justify-content: space-between;
+    .feature-publication-teaser-meta {
+      .authors {
+        @include link($color: $cigi-text-grey, $hover-color: $cigi-primary-colour);
+        font-size: 0.75em;
+        margin-bottom: 0;
+        margin-top: 0;
+        text-transform: uppercase;
+      }
 
-      .feature-publication-teaser-meta {
-        .authors {
-          @include link($color: $cigi-text-grey, $hover-color: $cigi-primary-colour);
-          font-size: 0.75em;
-          margin-bottom: 0;
-          margin-top: 0;
-          text-transform: uppercase;
-        }
+      .button-action {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        flex-shrink: 0;
+        font-size: 0.75em;
+        height: 25px;
+        justify-content: center;
+        margin-top: 0.5em;
+        padding: 7px 10px;
+        width: 25px;
 
-        .button-action {
-          align-items: center;
-          display: flex;
-          flex-direction: column;
-          flex-shrink: 0;
-          font-size: 0.75em;
-          height: 25px;
-          justify-content: center;
-          margin-top: 0.5em;
-          padding: 7px 10px;
-          width: 25px;
-
-          &:hover {
-            i {
-              color: $white;
-            }
-          }
-
+        &:hover {
           i {
-            color: $cigi-primary-colour;
-            margin-right: 0;
-            transition: color 0.25s ease;
+            color: $white;
           }
         }
 
-        .date {
-          color: $cigi-text-grey;
-          font-size: 0.75em;
-          text-transform: uppercase;
+        i {
+          color: $cigi-primary-colour;
+          margin-right: 0;
+          transition: color 0.25s ease;
         }
       }
 
-      .feature-publication-teaser-title {
-        h3 {
-          @include link($color: $black, $hover-color: $cigi-primary-colour);
-          font-size: 1.0625em;
-          line-height: 1.45;
-        }
+      .date {
+        color: $cigi-text-grey;
+        font-size: 0.75em;
+        text-transform: uppercase;
+      }
+    }
 
-        .topics {
-          color: $cigi-primary-colour;
-          margin-bottom: 0.5em;
-        }
+    .feature-publication-teaser-title {
+      h3 {
+        @include link($color: $black, $hover-color: $cigi-primary-colour);
+        font-size: 1.0625em;
+        line-height: 1.45;
+      }
+
+      .topics {
+        color: $cigi-primary-colour;
+        margin-bottom: 0.5em;
       }
     }
   }

--- a/cigionline/static/pages/home_page/css/_home_page.scss
+++ b/cigionline/static/pages/home_page/css/_home_page.scss
@@ -2,6 +2,15 @@
 @import '../../../css/includes/swiper';
 
 .homepage {
+  hr {
+    &.has-margin {
+      @include media-breakpoint-down(sm) {
+        margin-left: 15px;
+        margin-right: 15px;
+      }
+    }
+  }
+
   .homepage-featured {
     @include media-breakpoint-up(lg) {
       padding-top: 7em;
@@ -63,6 +72,8 @@
 
   .homepage-featured-publications {
     .homepage-featured-publication-row {
+      display: flex;
+
       &:last-child {
         article {
           @include media-breakpoint-down(sm) {

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -21,7 +21,7 @@
               {% include "includes/features/feature_content_large.html" with content=featured_pages.0 %}
             {% endif %}
           </div>
-          <hr>
+          <hr class="has-margin">
           <div class="col-12 col-md-4 featured-small">
           {% with featured_pages|slice:"4:" as featured_small %}
             {% for item in featured_small %}
@@ -111,7 +111,7 @@
             {% endif %}
           </div>
           {% if featured_multimedia|length > 1 %}
-          <hr>
+          <hr class="has-margin">
           <div class="col-12 col-md-4 featured-small">
             {% with featured_multimedia|slice:"1:" as featured_multimedia_small %}
               {% for item in  featured_multimedia_small %}

--- a/templates/includes/features/feature_publication_teaser.html
+++ b/templates/includes/features/feature_publication_teaser.html
@@ -1,29 +1,27 @@
 {% load wagtailcore_tags %}
 
 <article class="feature-publication-teaser">
-  <div class="feature-publication-teaser-content">
-    <div class="feature-publication-teaser-title">
-      {% include "includes/topics.html" with topics=publication.topics_sorted %}
-      <h3>
-        <a href="{% pageurl publication %}">
-          {{ publication.title }}
+  <div class="feature-publication-teaser-title">
+    {% include "includes/topics.html" with topics=publication.topics_sorted %}
+    <h3>
+      <a href="{% pageurl publication %}">
+        {{ publication.title }}
+      </a>
+    </h3>
+  </div>
+  <div class="feature-publication-teaser-meta">
+    {% include "includes/authors.html" with authors=publication.authors.all %}
+    {% if publication.from_the_archives %}
+      <div class="feature-content-from-the-archives">FROM THE ARCHIVES</div>
+    {% else %}
+      {% include "includes/date.html" with date=publication.publishing_date %}
+    {% endif %}
+    {% if publication.pdf_downloads %}
+      <button class="button-action">
+        <a href="{{ publication.pdf_downloads.0.value.file.url }}">
+          <i class="fa fas fa-download"></i>
         </a>
-      </h3>
-    </div>
-    <div class="feature-publication-teaser-meta">
-      {% include "includes/authors.html" with authors=publication.authors.all %}
-      {% if publication.from_the_archives %}
-        <div class="feature-content-from-the-archives">FROM THE ARCHIVES</div>
-      {% else %}
-        {% include "includes/date.html" with date=publication.publishing_date %}
-      {% endif %}
-      {% if publication.pdf_downloads %}
-        <button class="button-action">
-          <a href="{{ publication.pdf_downloads.0.value.file.url }}">
-            <i class="fa fas fa-download"></i>
-          </a>
-        </button>
-      {% endif %}
-    </div>
+      </button>
+    {% endif %}
   </div>
 </article>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#705

- Fixed main feature and featured multimedia sections' `<hr>` element (right after the big featured item) width on small screens
![image](https://user-images.githubusercontent.com/40705848/151424488-3ba3c1c7-5daf-4697-91a5-e79891d6f928.png)

- Fixed featured publications containers overflowing on medium screens 
![image](https://user-images.githubusercontent.com/40705848/151424700-872726de-d61d-46b3-bd66-80699b97064a.png)



#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
