### PR TITLE
CIGI-721: Improve image rendition caching

### DIFF
--- a/cigionline/settings/production.py
+++ b/cigionline/settings/production.py
@@ -54,7 +54,9 @@ if 'REDIS_URL' in os.environ:
         'renditions': {
             'BACKEND': 'django_redis.cache.RedisCache',
             'LOCATION': os.environ['REDIS_URL'],
+            'TIMEOUT': 31_536_000,
             'OPTIONS': {
+                'MAX_RETRIES': 200,
                 'CLIENT_CLASS': 'django_redis.client.DefaultClient',
                 'CONNECTION_POOL_KWARGS': {
                     'ssl_cert_reqs': False,


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#721

Ever since the migration to Wagtail, CIGIOnline has had image loading issues that returned 500 errors. Research indicated that this may be an issue with Wagtail's rendition process where multiple concurrent requests for images that don't have existing renditions will clog Heroku dynos, leading to time out. 

Previously we generated renditions manually in order to bypass this issue, and although it helped decrease occurrences, the core issue was never resolved.

This change adds additional settings that may allow redis to better cache the image renditions.


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [ ] Have you reviewed your own code changes?
- [ ] Has the issue owner reviewed your changes?
- [ ] Have you given the PR a descriptive title?
- [ ] Have you described your changes above? Always include screenshots if applicable.
- [ ] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
