### PR TITLE
CIGI-722: Add adv_cache_tag and use granular cache key for articles

### DIFF
--- a/articles/wagtail_hooks.py
+++ b/articles/wagtail_hooks.py
@@ -107,7 +107,7 @@ class ArticlePageModelAdmin(ModelAdmin):
     menu_label = 'Articles'
     menu_icon = 'duplicate'
     menu_order = 102
-    list_display = ('title', 'publishing_date', 'article_type', 'article_series', 'theme', 'live')
+    list_display = ('title', 'publishing_date', 'article_type', 'article_series', 'theme', 'live', 'id')
     list_filter = ('publishing_date', 'article_type', 'theme', 'live')
     search_fields = ('title',)
     ordering = ['-publishing_date']
@@ -129,7 +129,7 @@ class ArticleSeriesPageModelAdmin(ModelAdmin):
     menu_label = 'Article Series'
     menu_icon = 'list-ul'
     menu_order = 103
-    list_display = ('title', 'publishing_date', 'live')
+    list_display = ('title', 'publishing_date', 'live', 'id')
     list_filter = ('publishing_date', 'live')
     search_fields = ('title',)
     ordering = ['-publishing_date']

--- a/cigionline/settings/base.py
+++ b/cigionline/settings/base.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     'taggit',
     'wagtailmedia',
     'webpack_loader',
+    'adv_cache_tag',
 
     'django.contrib.admin',
     'django.contrib.auth',
@@ -213,6 +214,8 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
+
+ADV_CACHE_RESOLVE_NAME = True
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators

--- a/core/models.py
+++ b/core/models.py
@@ -470,6 +470,10 @@ class ContentPage(Page, SearchablePageAbstract):
 
         return recommended_content
 
+    def page_cache_key(self):
+        series = f'S:{self.specific.article_series.id}' if self.specific and self.specific.article_series else ''
+        return f'Ct:{self.specific.contenttype}Cst:{self.specific.contentsubtype}Id:{self.id}{series}'
+
     authors_panel = MultiFieldPanel(
         [
             InlinePanel('authors'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ coverage==5.5
 coveralls==3.1.0
 dj-database-url==0.5.0
 Django==3.2.4
+django-adv-cache-tag==1.1.3
 django-appconf==1.0.4
 django-compressor==2.4.1
 django-debug-toolbar==3.2.1

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load cache static wagtailcore_tags wagtailimages_tags webpack_loader core_tags %}
+{% load adv_cache static wagtailcore_tags wagtailimages_tags webpack_loader core_tags %}
 
 {% block meta_description %}
   {% if self.social_description %}
@@ -50,7 +50,7 @@
 
 {% block content %}
   {% preview_cache_bust as is_preview %}
-  {% cache 604800 article_content request.path request.user.username self.pk self.latest_revision_created_at|date:"c" request.GET.urlencode is_preview %}
+  {% cache 604800 self.page_cache_key request.path request.user.username self.pk self.latest_revision_created_at request.GET.urlencode is_preview %}
     {% block hero %}
       {% include "includes/heroes/hero_article.html" with title=self.title subtitle=self.subtitle %}
       {% if not self.expired_image and self.image_hero %}


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#722

- Added adv_cache_tag package in order to pass dynamic cache key into cache tag
- Use cache key that includes article id, article type and article series id for articles. This allows cache clearing of individual articles as well as all articles belonging to a specific series
- In order to test this locally, redis will need to be installed, and wagtail configured to use the local redis server

#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [x] Have you reviewed the code changes?
- [x] Have you tested the changes on Google Chrome?
- [x] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
