### PR TITLE
CIGI-736: Remove anchor tag from footnotes

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -230,7 +230,6 @@ class ArticlePage(
             'ul',
             'subscript',
             'superscript',
-            'anchor',
         ],
     )
     hero_title_placement = models.CharField(


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#736

This resolves a drafttail editor crash caused by using both anchors and links in the footnotes section. The anchor button was removed to reduce confusion.


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
