### PR TITLE
CIGI-769: Limit editor go_live_at options

### DIFF
--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -1,5 +1,5 @@
 from django.templatetags.static import static
-from django.utils.html import format_html, format_html_join
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from wagtail.admin.rich_text.converters.html_to_contentstate import (
     BlockElementHandler,

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -34,7 +34,7 @@ def editor_js():
                 }
                 $("#id_go_live_at").siblings("script").innerHtml = initDateTimeChooser(
                     "id_go_live_at",
-                    {"dayOfWeekStart": 0, "format": "Y-m-d H:i", "formatTime": "H:i", "allowTimes": times};
+                    {"dayOfWeekStart": 0, "format": "Y-m-d H:i", "formatTime": "H:i", "allowTimes": times}
                 );
                 $("#id_go_live_at").attr("readonly", "")
             });

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -1,5 +1,6 @@
-from django.utils.html import format_html
 from django.templatetags.static import static
+from django.utils.html import format_html, format_html_join
+from django.utils.safestring import mark_safe
 from wagtail.admin.rich_text.converters.html_to_contentstate import (
     BlockElementHandler,
     InlineStyleElementHandler,
@@ -14,6 +15,32 @@ from .models import Theme
 @hooks.register('insert_global_admin_css')
 def global_admin_css():
     return format_html('<link rel="stylesheet" href="{}">', static('css/admin.css'))
+
+
+@hooks.register('insert_editor_js')
+def editor_js():
+    return mark_safe(
+        """
+        <script>
+            /**
+            * @param {jQuery} $
+            */
+            window.addEventListener("DOMContentLoaded", (event) => {
+                var times = [];
+                for (let i = 0; i < 24; i++) {
+                    var hour = i < 10 ? "0" + i : i;
+                    times.push(hour + ":" + "00");
+                    times.push(hour + ":" + "30");
+                }
+                $("#id_go_live_at").siblings("script").innerHtml = initDateTimeChooser(
+                    "id_go_live_at",
+                    {"dayOfWeekStart": 0, "format": "Y-m-d H:i", "formatTime": "H:i", "allowTimes": times};
+                );
+                $("#id_go_live_at").attr("readonly", "")
+            });
+        </script>
+        """
+    )
 
 
 @hooks.register('register_rich_text_features')


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#769

- Changed go_live_at datetimepicker options to every 30 min
- Disabled input so editors cannot pick arbitrary time


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
