### PR TITLE
CIGI-770: Add query param and default date to annual reports timeline api

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,4 +1,5 @@
 from core.models import ContentPage
+from datetime import date
 from django.http import JsonResponse
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
@@ -6,7 +7,8 @@ from django.template.response import TemplateResponse
 
 def ar_timeline_pages(request):
     if request.user.is_authenticated:
-        content_pages = ContentPage.objects.live().filter(projectpage=None, publicationseriespage=None, multimediaseriespage=None, twentiethpagesingleton=None, multimediapage=None, articleseriespage=None).exclude(articlepage__article_type__title__in=['CIGI in the News', 'News Releases', 'Op-Eds']).filter(publishing_date__range=["2021-08-01", "2022-07-31"])
+        year = int(request.GET.get('year')) if request.GET.get('year') else date.today().year
+        content_pages = ContentPage.objects.live().filter(projectpage=None, publicationseriespage=None, multimediaseriespage=None, twentiethpagesingleton=None, multimediapage=None, articleseriespage=None).exclude(articlepage__article_type__title__in=['CIGI in the News', 'News Releases', 'Op-Eds']).filter(publishing_date__range=[f'{year - 1}-08-01', f'{year}-07-31'])
 
         json_items = []
 


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#770

- defaulted the timeline api date to current year
- add query param support

To test: 
- visit `api/ar_timeline_pages/` to get list of pages for the current year
- add query param 'year' to get list for other years - `api/ar_timeline_pages/?year=2021`


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
