### PR TITLE
CIGI-780: Update first-publish identification for purpose of publishing notifications

### DIFF
--- a/signals/apps.py
+++ b/signals/apps.py
@@ -43,7 +43,7 @@ def count_publishes(instance):
     all_unpublishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.unpublish').order_by('-timestamp')
     if all_unpublishes:
         latest_unpublish = all_unpublishes[0].timestamp
-        all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish', timestamp__gt=latest_unpublish)    
+        all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish', timestamp__gt=latest_unpublish)
     else:
         all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish')
 

--- a/signals/apps.py
+++ b/signals/apps.py
@@ -40,7 +40,8 @@ def datetime_compare(t1, t2):
 def count_publishes(instance):
     from wagtail.models import PageLogEntry
 
-    all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish')
+    latest_unpublish = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.unpublish').order_by('-timestamp')[0].timestamp
+    all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish', timestamp__gt=latest_unpublish)
 
     # for some reason, the PageLogEntry objects are not including the most recent publish that triggered this script
     # so a first-time publish would have a count of 0

--- a/signals/apps.py
+++ b/signals/apps.py
@@ -40,8 +40,12 @@ def datetime_compare(t1, t2):
 def count_publishes(instance):
     from wagtail.models import PageLogEntry
 
-    latest_unpublish = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.unpublish').order_by('-timestamp')[0].timestamp
-    all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish', timestamp__gt=latest_unpublish)
+    all_unpublishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.unpublish').order_by('-timestamp')
+    if all_unpublishes:
+        latest_unpublish = all_unpublishes[0].timestamp
+        all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish', timestamp__gt=latest_unpublish)    
+    else:
+        all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish')
 
     # for some reason, the PageLogEntry objects are not including the most recent publish that triggered this script
     # so a first-time publish would have a count of 0

--- a/signals/apps.py
+++ b/signals/apps.py
@@ -67,13 +67,11 @@ def instance_info(instance):
     publisher = f'{instance.get_latest_revision().user.first_name} {instance.get_latest_revision().user.last_name}'
     is_first_publish, is_first_publish_since_go_live_at = count_publishes(instance)
     is_scheduled_publish = (datetime_compare(instance.go_live_at, instance.last_published_at) and is_first_publish_since_go_live_at)
-    print(f'first: {is_first_publish}, scheduled: {is_scheduled_publish}')
     relative_url = instance.get_url_parts()[-1]  # last item in the tuple is the relative url to root; e.g. /articles/an-article/
     return title, authors, page_owner, content_type, publisher, is_first_publish, is_scheduled_publish, relative_url
 
 
 def notification_user_list(content_type, is_first_publish, is_scheduled_publish):
-    print(f'compiling user list for content type: {content_type}')
     from .models import PublishEmailNotification
 
     user_list = PublishEmailNotification.objects.filter(page_type_permissions__page_type__title__contains=content_type)
@@ -91,8 +89,6 @@ def notification_user_list(content_type, is_first_publish, is_scheduled_publish)
 
 
 def notification_email_list(notification_user_list):
-    print(f'compiling email list for users: {notification_user_list}')
-
     # going through User model because PublishEmailNotification returns UserProfile objects which has no 'email' attribute
     from django.contrib.auth.models import User
 
@@ -138,10 +134,6 @@ def send_email(title, authors, page_owner, content_type, recipients, publisher, 
 
     if notifications_on():
         msg.send()
-    # print email content when notification is off
-    else:
-        print(html_content)
-    print('notification emails are sent to', recipients)
 
 
 def send_to_slack(title, authors, page_owner, content_type, publisher, publish_phrasing, page_url, header_label):
@@ -160,8 +152,6 @@ def send_to_slack(title, authors, page_owner, content_type, publisher, publish_p
 
     if notifications_on():
         requests.post(url, json.dumps(values))
-    else:
-        print(values)  # print what would've been sent to Slack
 
 
 # Let everyone know when a new page is published


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#780

- First publish now identified by counting publishes since the latest unpublish event, filtered by its timestamp
- Those without an unpublish event behave as previously

Please test cases:
1. first publish; no unpublish history. Expecting: "first: True" in logs
2. republish; no unpublish history. Expecting: "first: False" in logs
3. unpublished once; first publish since. Expecting: "first: True" in logs
4. unpublished more than once; first publish since. Expecting: "first: True" in logs
5. unpublished once; republish since. Expecting: "first: False" in logs


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
