### PR TITLE
CIGI-795: update logic to identify scheduling actions in Wagtail 4.0

### DIFF
--- a/signals/apps.py
+++ b/signals/apps.py
@@ -52,7 +52,6 @@ def count_publishes(instance):
     all_unpublishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.unpublish').order_by('-timestamp')
     if all_unpublishes:
         latest_unpublish = all_unpublishes[0].timestamp
-        print(f'unpublish: {latest_unpublish}')
         all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish', timestamp__gt=latest_unpublish)
     else:
         all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish')
@@ -158,11 +157,9 @@ def send_to_slack(title, authors, page_owner, content_type, publisher, publish_p
 
 # Let everyone know when a new page is published
 def send_notifications(sender, **kwargs):
-    print('signal triggered!!!')
     instance = kwargs['instance']
     revision = kwargs['revision']
     publish_trigger_type = get_publish_trigger_type(instance, revision)
-    print(f'trigger: {publish_trigger_type}')
 
     # first ever scheduled publishes trigger this signal unexpectedly upon scheduling; filter them out
     if publish_trigger_type != 'scheduling':
@@ -173,8 +170,6 @@ def send_notifications(sender, **kwargs):
             publish_phrasing = set_publish_phrasing(is_first_publish)
             page_url = f'{get_site_url()}{relative_url}'
             header_label = get_header_label()
-
-            print(f'first: {is_first_publish}; scheduled: {is_scheduled_publish}')
 
             if is_first_publish:
                 send_to_slack(title, authors, page_owner, content_type, publisher, publish_phrasing, page_url, header_label)

--- a/signals/apps.py
+++ b/signals/apps.py
@@ -52,6 +52,7 @@ def count_publishes(instance):
     all_unpublishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.unpublish').order_by('-timestamp')
     if all_unpublishes:
         latest_unpublish = all_unpublishes[0].timestamp
+        print(f'unpublish: {latest_unpublish}')
         all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish', timestamp__gt=latest_unpublish)
     else:
         all_publishes = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish')

--- a/signals/apps.py
+++ b/signals/apps.py
@@ -38,6 +38,14 @@ def datetime_compare(t1, t2):
     return False
 
 
+def get_publish_trigger_type(instance, revision):
+    if revision.approved_go_live_at:
+        if datetime_compare(instance.go_live_at, instance.last_published_at):
+            return 'scheduled'
+        return 'scheduling'
+    return 'manual'
+
+
 def count_publishes(instance):
     from wagtail.models import PageLogEntry
 
@@ -52,12 +60,7 @@ def count_publishes(instance):
     # so a first-time publish would have a count of 0
     is_first_publish = (len(all_publishes) == 0)
 
-    if instance.go_live_at:
-        publishes_since_go_live_at = PageLogEntry.objects.filter(page_id=instance.id, action='wagtail.publish', timestamp__gte=instance.go_live_at)
-        is_first_publish_since_go_live_at = (len(publishes_since_go_live_at) == 0)
-    else:
-        is_first_publish_since_go_live_at = False
-    return is_first_publish, is_first_publish_since_go_live_at
+    return is_first_publish
 
 
 def instance_info(instance):
@@ -66,10 +69,9 @@ def instance_info(instance):
     page_owner = f'{instance.owner.first_name} {instance.owner.last_name}'
     content_type = 'Articles' if instance.contenttype == 'Opinion' else instance.contenttype  # adjust ContentPage.contenttype to match page_type
     publisher = f'{instance.get_latest_revision().user.first_name} {instance.get_latest_revision().user.last_name}'
-    is_first_publish, is_first_publish_since_go_live_at = count_publishes(instance)
-    is_scheduled_publish = (datetime_compare(instance.go_live_at, instance.last_published_at) and is_first_publish_since_go_live_at)
+    is_first_publish = count_publishes(instance)
     relative_url = instance.get_url_parts()[-1]  # last item in the tuple is the relative url to root; e.g. /articles/an-article/
-    return title, authors, page_owner, content_type, publisher, is_first_publish, is_scheduled_publish, relative_url
+    return title, authors, page_owner, content_type, publisher, is_first_publish, relative_url
 
 
 def notification_user_list(content_type, is_first_publish, is_scheduled_publish):
@@ -155,17 +157,23 @@ def send_to_slack(title, authors, page_owner, content_type, publisher, publish_p
 
 # Let everyone know when a new page is published
 def send_notifications(sender, **kwargs):
+    print('signal triggered!!!')
     instance = kwargs['instance']
     revision = kwargs['revision']
+    publish_trigger_type = get_publish_trigger_type(instance, revision)
+    print(f'trigger: {publish_trigger_type}')
 
     # first ever scheduled publishes trigger this signal unexpectedly upon scheduling; filter them out
-    if not revision.approved_go_live_at:
+    if publish_trigger_type != 'scheduling':
         # wrap in try/except to not disrupt normal operations if a page is successfully published but email could not be sent
         try:
-            title, authors, page_owner, content_type, publisher, is_first_publish, is_scheduled_publish, relative_url = instance_info(instance)
+            title, authors, page_owner, content_type, publisher, is_first_publish, relative_url = instance_info(instance)
+            is_scheduled_publish = publish_trigger_type == 'scheduled'
             publish_phrasing = set_publish_phrasing(is_first_publish)
             page_url = f'{get_site_url()}{relative_url}'
             header_label = get_header_label()
+
+            print(f'first: {is_first_publish}; scheduled: {is_scheduled_publish}')
 
             if is_first_publish:
                 send_to_slack(title, authors, page_owner, content_type, publisher, publish_phrasing, page_url, header_label)


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#795

3 trigger types:
- "scheduled" - when `revision.approved_go_live_at` is populated and the timestamp is within 1hr of the latest published timestamp
- "scheduling" - when `revision.approved_go_live_at` is populated but not the second condition above
- "manual" - when `revision.approved_go_live_at` is **not** populated