### PR TITLE
CIGI-833: Fix to Newsletter internal links having different colour vs intended

### DIFF
--- a/streams/blocks.py
+++ b/streams/blocks.py
@@ -5,6 +5,12 @@ from django.db import models
 from django.forms.utils import flatatt
 from django.utils import timezone
 from django.utils.html import format_html, format_html_join
+<<<<<<< Updated upstream
+=======
+from django.utils.safestring import mark_safe
+from distutils.log import error
+import wagtail.core.rich_text as rich_text
+>>>>>>> Stashed changes
 from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail import blocks
 from wagtail.documents.blocks import DocumentChooserBlock
@@ -871,13 +877,13 @@ class NewsletterBlock(blocks.StructBlock):
             if is_str:
                 text_soup = BeautifulSoup(context['text'], 'html.parser')
             else:
-                text_soup = BeautifulSoup(context['text'].source, 'html.parser')
+                text_soup = BeautifulSoup(rich_text.expand_db_html(context['text'].source), 'html.parser')
             for link in text_soup.findAll('a'):
                 link['style'] = 'text-decoration: none; color: #ee1558;'
             if is_str:
                 context['text'] = str(text_soup)
             else:
-                context['text'].source = str(text_soup)
+                context['text'] = mark_safe(str(text_soup))
 
         return context
 

--- a/streams/blocks.py
+++ b/streams/blocks.py
@@ -5,12 +5,8 @@ from django.db import models
 from django.forms.utils import flatatt
 from django.utils import timezone
 from django.utils.html import format_html, format_html_join
-<<<<<<< Updated upstream
-=======
 from django.utils.safestring import mark_safe
-from distutils.log import error
 import wagtail.core.rich_text as rich_text
->>>>>>> Stashed changes
 from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail import blocks
 from wagtail.documents.blocks import DocumentChooserBlock

--- a/templates/streams/newsletter/content_block.html
+++ b/templates/streams/newsletter/content_block.html
@@ -92,7 +92,7 @@
                 <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   <div
                     style="font-family:Helvetica, Arial, sans-serif;font-size:16px;font-style:normal;font-weight:400;line-height:21px;text-align:left;color:#696969;">
-                    {{ text|richtext }}
+                    {{ text }}
                   </div>
                 </td>
               </tr>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#833

- expand block text into html string
- target _a_ elements inside block text and add inline styling
- this allows targeting _a_ elements of internal links - which are normally stored as pseudo html strings whose elements are not targetable by BeautifulSoup _findall_ function; while avoids unwanted changes on title links.


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
