### PR TITLE
CIGI-887: Render different content based on mailchimp API status while subscribing

### DIFF
--- a/subscribe/models.py
+++ b/subscribe/models.py
@@ -10,6 +10,7 @@ from streams.blocks import ParagraphBlock
 from mailchimp_marketing.api_client import ApiClientError
 import mailchimp_marketing as MailchimpMarketing
 import logging
+import json
 
 api_key = None
 server = None
@@ -100,6 +101,10 @@ class SubscribePage(
 
             except ApiClientError as error:
                 logger.error('An error occurred with Mailchimp: {}'.format(error.text))
+                if json.loads(error.text)['title'] == 'Member Exists':
+                    context['status'] = 'subscribed'
+                else:
+                    context['status'] = 'error'
 
             return render(request, self.landing_page_template, context)
 

--- a/templates/subscribe/subscribe_page_landing.html
+++ b/templates/subscribe/subscribe_page_landing.html
@@ -7,8 +7,15 @@
 {% endblock %}
 
 {% block content %}
-  {% include "includes/heroes/hero_plain.html" with title="Thank you for signing up!" %}
-  {{ self.landing_page_body }}
+  {% if status == 'subscribed' %}
+    {% include "includes/heroes/hero_plain.html" with title="You are already subscribed!" %}
+  {% elif status == 'error' %}
+    {% include "includes/heroes/hero_plain.html" with title="Apologies, an error occurred during the sign up process. Please try again." %}
+  {% else %}
+    {% include "includes/heroes/hero_plain.html" with title="Thank you for signing up!" %}
+    {{ self.landing_page_body }}
+  {% endif %}
+
   <section class="social-links">
     <div class="container">
       <div class="row d-block">


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#887
- Should render different page contents if the status is:
-- error
-- user already subscribed
-- successfully subscribed

#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [ ] Have you reviewed your own code changes?
- [ ] Has the issue owner reviewed your changes?
- [ ] Have you given the PR a descriptive title?
- [ ] Have you described your changes above? Always include screenshots if applicable.
- [ ] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
