### PR TITLE
CIGI-923: Hide PeoplePages tagged as external profile

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -825,6 +825,7 @@ class ArticleSeriesPage(
                         'id': person.author.id,
                         'title': person.author.title,
                         'url': person.author.url,
+                        'is_external_profile': person.author.is_external_profile,
                     })
                     item_people.add(person.author.title)
         return series_contributors

--- a/cigionline/static/css/global/_helpers.scss
+++ b/cigionline/static/css/global/_helpers.scss
@@ -188,7 +188,8 @@
   .article-authors {
     @include link($color: $cigi-text-grey, $hover-color: $cigi-primary-colour);
 
-    a {
+    a,
+    span {
       @include comma-separated;
 
       &:not(:only-child) {

--- a/cigionline/static/css/includes/_authors.scss
+++ b/cigionline/static/css/includes/_authors.scss
@@ -4,6 +4,7 @@
   line-height: 1.25em;
   margin-bottom: 0.5em;
   margin-top: 1.5em;
+  color: $cigi-dark-grey;
 
   .block-author {
     @include comma-separated;

--- a/cigionline/static/css/includes/_hero_publication_book.scss
+++ b/cigionline/static/css/includes/_hero_publication_book.scss
@@ -32,6 +32,7 @@ section {
       font-size: 1.125em;
       margin-bottom: 0;
       margin-top: 0;
+      color: $white
     }
 
     .social-share-list {

--- a/cigionline/static/css/layout/_tables.scss
+++ b/cigionline/static/css/layout/_tables.scss
@@ -99,7 +99,7 @@ table {
 
         .table-infos-function {
           color: $cigi-text-grey;
-          font-size: .9em;
+          font-size: 0.9em;
         }
 
         .custom-text-list {
@@ -107,6 +107,16 @@ table {
 
           &.author-list {
             color: $cigi-text-grey;
+          }
+        }
+
+        a {
+          &.table-content-link {
+            &.table-content-link-black {
+              &:hover {
+                color: $cigi-primary-colour;
+              }
+            }
           }
         }
 
@@ -120,10 +130,6 @@ table {
 
           &.table-content-link-black {
             color: $cigi-text-grey;
-
-            &:hover {
-              color: $cigi-primary-colour;
-            }
           }
         }
 
@@ -274,7 +280,6 @@ table {
 
 //CORE RELATED FILES TABLE
 
-
 .table-related-files {
   margin-bottom: 3em;
 
@@ -282,8 +287,8 @@ table {
     tr {
       th {
         border-bottom-color: $border-box;
-        padding-bottom: .5em;
-        padding-top: .5em;
+        padding-bottom: 0.5em;
+        padding-top: 0.5em;
       }
     }
   }
@@ -297,9 +302,9 @@ table {
       }
 
       td {
-        font-size: .9em;
-        padding-bottom: .5em;
-        padding-top: .5em;
+        font-size: 0.9em;
+        padding-bottom: 0.5em;
+        padding-top: 0.5em;
       }
     }
   }
@@ -308,7 +313,7 @@ table {
     @include media-breakpoint-down(sm) {
       width: 80%;
     }
-    padding-right: .5em;
+    padding-right: 0.5em;
     width: 85%;
   }
 }

--- a/cigionline/static/js/components/ArticleListingSimple.js
+++ b/cigionline/static/js/components/ArticleListingSimple.js
@@ -15,9 +15,13 @@ function ArticleListingSimple(props) {
       )}
       <p className="article-authors">
         {row.authors.map((author) => (
-          <a key={`${row.id}-author-${author.id}`} href={author.url}>
-            {author.title}
-          </a>
+          !author.is_external_profile ? (
+            <a key={`${row.id}-author-${author.id}`} href={author.url}>
+              {author.title}
+            </a>
+          ) : (
+            <span key={`${row.id}-author-${author.id}`}>{author.title}</span>
+          )
         ))}
       </p>
     </article>

--- a/cigionline/static/js/components/ArticleSeriesListing.js
+++ b/cigionline/static/js/components/ArticleSeriesListing.js
@@ -22,22 +22,32 @@ function ArticleSeriesListing(props) {
         <h2 className="article-series-title">
           <a href={row.url}>{row.title}</a>
         </h2>
-        <div className="article-series-short-description" dangerouslySetInnerHTML={{ __html: row.short_description }} />
+        <div
+          className="article-series-short-description"
+          dangerouslySetInnerHTML={{ __html: row.short_description }}
+        />
         <div className="article-series-contributors">
           <h3>Contributors</h3>
           <ul>
             {row.series_contributors.map((person) => (
               <li key={`${row.id}-contributor-${person.id}`}>
-                <a href={person.url}>
-                  {person.title}
-                </a>
+                {person.is_external_profile ? (
+                  <span>{person.title}</span>
+                ) : (
+                  <a href={person.url}>{person.title}</a>
+                )}
               </li>
             ))}
           </ul>
         </div>
       </div>
       <a href={row.url} className="article-series-image">
-        <img src={row.image_poster_url} alt={row.image_poster_caption} width="672" height="895" />
+        <img
+          src={row.image_poster_url}
+          alt={row.image_poster_caption}
+          width="672"
+          height="895"
+        />
       </a>
     </article>
   );
@@ -48,18 +58,23 @@ ArticleSeriesListing.propTypes = {
     id: PropTypes.number,
     image_poster_caption: PropTypes.string,
     image_poster_url: PropTypes.string,
-    series_contributors: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      title: PropTypes.string,
-      url: PropTypes.string,
-    })),
+    series_contributors: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        title: PropTypes.string,
+        url: PropTypes.string,
+        is_external_profile: PropTypes.bool,
+      }),
+    ),
     short_description: PropTypes.string,
     title: PropTypes.string,
-    topics: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      title: PropTypes.string,
-      url: PropTypes.string,
-    })),
+    topics: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        title: PropTypes.string,
+        url: PropTypes.string,
+      }),
+    ),
     url: PropTypes.string,
   }).isRequired,
 };

--- a/cigionline/static/js/components/MediaListing.js
+++ b/cigionline/static/js/components/MediaListing.js
@@ -8,9 +8,7 @@ function MediaListing(props) {
   return (
     <tr>
       <td colSpan="6">
-        <div className="table-mobile-text">
-          Title
-        </div>
+        <div className="table-mobile-text">Title</div>
         <div className="table-infos-wrapper">
           <span className="table-icon icon-media">
             <i className="fal fa-bullhorn" />
@@ -21,32 +19,39 @@ function MediaListing(props) {
             </a>
             {row.publishing_date && (
               <div className="table-infos-meta">
-                {DateTime.fromISO(row.publishing_date).toLocaleString(DateTime.DATE_FULL)}
+                {DateTime.fromISO(row.publishing_date).toLocaleString(
+                  DateTime.DATE_FULL,
+                )}
               </div>
             )}
           </div>
         </div>
       </td>
       <td colSpan="1">
-        <div className="table-mobile-text">
-          Expert
-        </div>
+        <div className="table-mobile-text">Expert</div>
         <div className="table-content">
           <ul className="custom-text-list author-list">
             {row.cigi_people_mentioned.map((person) => (
               <li key={`${row.id}-person-${person.id}`}>
-                <a href={person.url} className="table-content-link table-content-link-black">
-                  {person.title}
-                </a>
+                {!person.is_external_profile ? (
+                  <a
+                    href={person.url}
+                    className="table-content-link table-content-link-black"
+                  >
+                    {person.title}
+                  </a>
+                ) : (
+                  <span className="table-content-link table-content-link-black">
+                    {person.title}
+                  </span>
+                )}
               </li>
             ))}
           </ul>
         </div>
       </td>
       <td colSpan="1">
-        <div className="table-mobile-text">
-          Type
-        </div>
+        <div className="table-mobile-text">Type</div>
         <div className="table-content">
           <ul className="custom-text-list">
             <li key={`${row.id}-contentsubtype`} className="table-infos-meta">
@@ -56,9 +61,7 @@ function MediaListing(props) {
         </div>
       </td>
       <td colSpan="4">
-        <div className="table-mobile-text">
-          Topic
-        </div>
+        <div className="table-mobile-text">Topic</div>
         <div className="table-content">
           <ul className="custom-text-list">
             {row.topics.map((topic) => (
@@ -77,20 +80,25 @@ function MediaListing(props) {
 
 MediaListing.propTypes = {
   row: PropTypes.shape({
-    cigi_people_mentioned: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      title: PropTypes.string,
-      url: PropTypes.string,
-    })),
+    cigi_people_mentioned: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        title: PropTypes.string,
+        url: PropTypes.string,
+        is_external_profile: PropTypes.bool,
+      }),
+    ),
     contentsubtype: PropTypes.string,
     id: PropTypes.number,
     publishing_date: PropTypes.string,
     title: PropTypes.string,
-    topics: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      title: PropTypes.string,
-      url: PropTypes.string,
-    })),
+    topics: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        title: PropTypes.string,
+        url: PropTypes.string,
+      }),
+    ),
     url: PropTypes.string,
   }).isRequired,
 };

--- a/cigionline/static/js/components/MultimediaListing.js
+++ b/cigionline/static/js/components/MultimediaListing.js
@@ -10,7 +10,10 @@ function MultimediaListing(props) {
   return (
     <div className="col multimedia-list-col">
       <a href={row.url} className="multimedia-card-image">
-        <div className="img-wrapper" style={{ backgroundImage: `url(${row.image_hero_url})` }} />
+        <div
+          className="img-wrapper"
+          style={{ backgroundImage: `url(${row.image_hero_url})` }}
+        />
         <div className="multimedia-image-type">
           {row.contentsubtype === 'Audio' ? (
             <i className="fas fa-volume-up" />
@@ -29,16 +32,16 @@ function MultimediaListing(props) {
         ))}
       </ul>
       <p className="multimedia-card-title">
-        <a href={row.url}>
-          {row.title}
-        </a>
+        <a href={row.url}>{row.title}</a>
       </p>
       <ul className="custom-text-list multimedia-card-speakers-list">
         {row.authors.slice(0, 3).map((author) => (
           <li key={`${row.id}-author-${author.id}`}>
-            <a href={author.url}>
-              {author.title}
-            </a>
+            {!author.is_external_profile ? (
+              <a href={author.url}>{author.title}</a>
+            ) : (
+              <span>{author.title}</span>
+            )}
           </li>
         ))}
         {row.authors.length > 3 && (
@@ -47,7 +50,9 @@ function MultimediaListing(props) {
       </ul>
       {row.publishing_date && (
         <p className="multimedia-card-date">
-          {DateTime.fromISO(row.publishing_date).toLocaleString(DateTime.DATE_FULL)}
+          {DateTime.fromISO(row.publishing_date).toLocaleString(
+            DateTime.DATE_FULL,
+          )}
         </p>
       )}
     </div>
@@ -56,21 +61,26 @@ function MultimediaListing(props) {
 
 MultimediaListing.propTypes = {
   row: PropTypes.shape({
-    authors: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      type: PropTypes.string,
-      value: PropTypes.any,
-    })),
+    authors: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        type: PropTypes.string,
+        value: PropTypes.any,
+        is_external_profile: PropTypes.bool,
+      }),
+    ),
     contentsubtype: PropTypes.string,
     id: PropTypes.number,
     image_hero_url: PropTypes.string,
     publishing_date: PropTypes.string,
     title: PropTypes.string.isRequired,
-    topics: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      title: PropTypes.string,
-      url: PropTypes.string,
-    })),
+    topics: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        title: PropTypes.string,
+        url: PropTypes.string,
+      }),
+    ),
     url: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/cigionline/static/js/components/OpinionListing.js
+++ b/cigionline/static/js/components/OpinionListing.js
@@ -8,9 +8,7 @@ function OpinionListing(props) {
   return (
     <tr>
       <td colSpan="6">
-        <div className="table-mobile-text">
-          Title
-        </div>
+        <div className="table-mobile-text">Title</div>
         <div className="table-infos-wrapper">
           <span className="table-icon icon-opinion">
             <i className="fal fa-comment-dots" />
@@ -21,32 +19,39 @@ function OpinionListing(props) {
             </a>
             {row.publishing_date && (
               <div className="table-infos-meta">
-                {DateTime.fromISO(row.publishing_date).toLocaleString(DateTime.DATE_FULL)}
+                {DateTime.fromISO(row.publishing_date).toLocaleString(
+                  DateTime.DATE_FULL,
+                )}
               </div>
             )}
           </div>
         </div>
       </td>
       <td colSpan="3">
-        <div className="table-mobile-text">
-          Author
-        </div>
+        <div className="table-mobile-text">Author</div>
         <div className="table-content">
           <ul className="custom-text-list author-list">
             {row.authors.map((author) => (
               <li key={`${row.id}-author-${author.id}`}>
-                <a href={author.url} className="table-content-link table-content-link-black">
-                  {author.title}
-                </a>
+                {!author.is_external_profile ? (
+                  <a
+                    href={author.url}
+                    className="table-content-link table-content-link-black"
+                  >
+                    {author.title}
+                  </a>
+                ) : (
+                  <span className="table-content-link table-content-link-black">
+                    {author.title}
+                  </span>
+                )}
               </li>
             ))}
           </ul>
         </div>
       </td>
       <td colSpan="3">
-        <div className="table-mobile-text">
-          Topic
-        </div>
+        <div className="table-mobile-text">Topic</div>
         <div className="table-content">
           <ul className="custom-text-list">
             {row.topics.map((topic) => (
@@ -65,19 +70,24 @@ function OpinionListing(props) {
 
 OpinionListing.propTypes = {
   row: PropTypes.shape({
-    authors: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      type: PropTypes.string,
-      value: PropTypes.any,
-    })),
+    authors: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        type: PropTypes.string,
+        value: PropTypes.any,
+        is_external_profile: PropTypes.bool,
+      }),
+    ),
     id: PropTypes.number,
     publishing_date: PropTypes.string,
     title: PropTypes.string,
-    topics: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      title: PropTypes.string,
-      url: PropTypes.string,
-    })),
+    topics: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        title: PropTypes.string,
+        url: PropTypes.string,
+      }),
+    ),
     url: PropTypes.string,
   }).isRequired,
 };

--- a/cigionline/static/js/components/ProjectContentListing.js
+++ b/cigionline/static/js/components/ProjectContentListing.js
@@ -63,9 +63,18 @@ function ProjectContentListing(props) {
           <ul className="custom-text-list author-list">
             {row.authors.map((author) => (
               <li key={`${row.id}-author-${author.id}`}>
-                <a href={author.url} className="table-content-link table-content-link-black">
-                  {author.title}
-                </a>
+                {!author.is_external_profile ? (
+                  <a
+                    href={author.url}
+                    className="table-content-link table-content-link-black"
+                  >
+                    {author.title}
+                  </a>
+                ) : (
+                  <span className="table-content-link table-content-link-black">
+                    {author.title}
+                  </span>
+                )}
               </li>
             ))}
           </ul>

--- a/cigionline/static/js/components/PublicationListing.js
+++ b/cigionline/static/js/components/PublicationListing.js
@@ -9,9 +9,7 @@ function PublicationListing(props) {
   return (
     <tr>
       <td colSpan="6">
-        <div className="table-mobile-text">
-          Title
-        </div>
+        <div className="table-mobile-text">Title</div>
         <div className="table-infos-wrapper">
           <span className="table-icon icon-publication">
             <i className="fal fa-file-alt" />
@@ -22,16 +20,16 @@ function PublicationListing(props) {
             </a>
             {row.publishing_date && (
               <div className="table-infos-meta">
-                {DateTime.fromISO(row.publishing_date).toLocaleString(DateTime.DATE_FULL)}
+                {DateTime.fromISO(row.publishing_date).toLocaleString(
+                  DateTime.DATE_FULL,
+                )}
               </div>
             )}
           </div>
         </div>
       </td>
       <td colSpan="2">
-        <div className="table-mobile-text">
-          Topic
-        </div>
+        <div className="table-mobile-text">Topic</div>
         <div className="table-content">
           <ul className="custom-text-list">
             {row.topics.map((topic) => (
@@ -45,28 +43,38 @@ function PublicationListing(props) {
         </div>
       </td>
       <td colSpan="3">
-        <div className="table-mobile-text">
-          Expert
-        </div>
+        <div className="table-mobile-text">Expert</div>
         <div className="table-content">
           <ul className="custom-text-list author-list">
             {row.authors.map((author) => (
               <li key={`${row.id}-author-${author.id}`}>
-                <a href={author.url} className="table-content-link table-content-link-black">
-                  {author.title}
-                </a>
+                {!author.is_external_profile ? (
+                  <a
+                    href={author.url}
+                    className="table-content-link table-content-link-black"
+                  >
+                    {author.title}
+                  </a>
+                ) : (
+                  <span className="table-content-link table-content-link-black">
+                    {author.title}
+                  </span>
+                )}
               </li>
             ))}
           </ul>
         </div>
       </td>
       <td colSpan="0">
-        <div className="table-mobile-text">
-          PDF
-        </div>
+        <div className="table-mobile-text">PDF</div>
         <div className="table-content">
           {row.pdf_download && (
-            <a href={row.pdf_download} className="table-btn-icon track-cta" data-cta="publication-pdf" onClick={handleCTAClick}>
+            <a
+              href={row.pdf_download}
+              className="table-btn-icon track-cta"
+              data-cta="publication-pdf"
+              onClick={handleCTAClick}
+            >
               <i className="fa fas fa-download" />
             </a>
           )}
@@ -78,20 +86,25 @@ function PublicationListing(props) {
 
 PublicationListing.propTypes = {
   row: PropTypes.shape({
-    authors: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      title: PropTypes.string,
-      url: PropTypes.string,
-    })),
+    authors: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        title: PropTypes.string,
+        url: PropTypes.string,
+        is_external_profile: PropTypes.bool,
+      }),
+    ),
     id: PropTypes.number,
     pdf_download: PropTypes.string,
     publishing_date: PropTypes.string,
     title: PropTypes.string.isRequired,
-    topics: PropTypes.arrayOf(PropTypes.shape({
-      id: PropTypes.number,
-      title: PropTypes.string,
-      url: PropTypes.string,
-    })),
+    topics: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        title: PropTypes.string,
+        url: PropTypes.string,
+      }),
+    ),
     url: PropTypes.string.isRequired,
   }).isRequired,
   handleCTAClick: PropTypes.func.isRequired,

--- a/cigionline/static/js/components/PublicationListingSimple.js
+++ b/cigionline/static/js/components/PublicationListingSimple.js
@@ -15,7 +15,7 @@ function PublicationListingSimple(props) {
       )}
       <p className="article-authors">
         {row.authors.map((author) => (
-          author.is_external_profile ? (
+          !author.is_external_profile ? (
             <a key={`${row.id}-author-${author.id}`} href={author.url}>
               {author.title}
             </a>

--- a/cigionline/static/js/components/PublicationListingSimple.js
+++ b/cigionline/static/js/components/PublicationListingSimple.js
@@ -15,9 +15,13 @@ function PublicationListingSimple(props) {
       )}
       <p className="article-authors">
         {row.authors.map((author) => (
-          <a key={`${row.id}-author-${author.id}`} href={author.url}>
-            {author.title}
-          </a>
+          author.is_external_profile ? (
+            <a key={`${row.id}-author-${author.id}`} href={author.url}>
+              {author.title}
+            </a>
+          ) : (
+            <span key={`${row.id}-author-${author.id}`}>{author.title}</span>
+          )
         ))}
       </p>
     </article>
@@ -30,6 +34,7 @@ PublicationListingSimple.propTypes = {
       id: PropTypes.number,
       type: PropTypes.string,
       value: PropTypes.any,
+      is_external_profile: PropTypes.bool,
     })),
     id: PropTypes.number,
     publishing_date: PropTypes.string,

--- a/cigionline/static/js/components/ResearchContentListing.js
+++ b/cigionline/static/js/components/ResearchContentListing.js
@@ -68,9 +68,18 @@ function ResearchContentListing(props) {
           <ul className="custom-text-list author-list">
             {row.authors.map((author) => (
               <li key={`${row.id}-author-${author.id}`}>
-                <a href={author.url} className="table-content-link table-content-link-black">
-                  {author.title}
-                </a>
+                {!author.is_external_profile ? (
+                  <a
+                    href={author.url}
+                    className="table-content-link table-content-link-black"
+                  >
+                    {author.title}
+                  </a>
+                ) : (
+                  <span className="table-content-link table-content-link-black">
+                    {author.title}
+                  </span>
+                )}
               </li>
             ))}
           </ul>
@@ -126,6 +135,7 @@ ResearchContentListing.propTypes = {
       id: PropTypes.number,
       type: PropTypes.string,
       value: PropTypes.any,
+      is_external_profile: PropTypes.bool,
     })),
     contentsubtype: PropTypes.string,
     contenttype: PropTypes.string,

--- a/cigionline/static/js/components/SearchResultListing.js
+++ b/cigionline/static/js/components/SearchResultListing.js
@@ -66,12 +66,14 @@ function SearchResultListing(props) {
           <i className="fal fa-copy" />
         </span>
       )}
-      {row.contenttype === 'Opinion' && ['Opinion', 'Interviews', 'Op-Eds'].includes(row.contentsubtype) && (
+      {row.contenttype === 'Opinion'
+        && ['Opinion', 'Interviews', 'Op-Eds'].includes(row.contentsubtype) && (
         <span className="table-icon icon-opinion">
           <i className="fal fa-comment-dots" />
         </span>
       )}
-      {row.contenttype === 'Opinion' && ['CIGI in the News', 'News Releases'].includes(row.contentsubtype) && (
+      {row.contenttype === 'Opinion'
+        && ['CIGI in the News', 'News Releases'].includes(row.contentsubtype) && (
         <span className="table-icon icon-media">
           <i className="fal fa-bullhorn" />
         </span>
@@ -126,20 +128,23 @@ function SearchResultListing(props) {
           <ul className="custom-text-list search-result-meta">
             {row.authors.map((author) => (
               <li key={`${row.id}-author-${author.id}`}>
-                <a href={author.url}>{author.title}</a>
+                {!author.is_external_profile ? (
+                  <a href={author.url}>{author.title}</a>
+                ) : (
+                  <span>{author.title}</span>
+                )}
               </li>
             ))}
           </ul>
         )}
         {highlights.length > 0 && (
           <p className="search-result-highlight">
-            {row.highlights
-              .map((highlight, index) => (
-                <span
-                  key={`${row.id}-highlight-${index}`}
-                  dangerouslySetInnerHTML={{ __html: highlight }}
-                />
-              ))}
+            {row.highlights.map((highlight, index) => (
+              <span
+                key={`${row.id}-highlight-${index}`}
+                dangerouslySetInnerHTML={{ __html: highlight }}
+              />
+            ))}
           </p>
         )}
         {row.highlights.length === 0 && row.snippet && (
@@ -155,7 +160,9 @@ function SearchResultListing(props) {
           <p className="search-result-highlight">
             View results related to this topic.
           </p>
-        ) : ''}
+        ) : (
+          ''
+        )}
       </div>
     </article>
   );
@@ -168,6 +175,7 @@ SearchResultListing.propTypes = {
         id: PropTypes.number,
         type: PropTypes.string,
         value: PropTypes.any,
+        is_external_profile: PropTypes.bool,
       }),
     ),
     snippet: PropTypes.string,

--- a/cigionline/static/js/components/TopicContentListing.js
+++ b/cigionline/static/js/components/TopicContentListing.js
@@ -63,9 +63,18 @@ function TopicContentListing(props) {
           <ul className="custom-text-list author-list">
             {row.authors && row.authors.map((author) => (
               <li key={`${row.id}-author-${author.id}`}>
-                <a href={author.url} className="table-content-link table-content-link-black">
-                  {author.title}
-                </a>
+                {!author.is_external_profile ? (
+                  <a
+                    href={author.url}
+                    className="table-content-link table-content-link-black"
+                  >
+                    {author.title}
+                  </a>
+                ) : (
+                  <span className="table-content-link table-content-link-black">
+                    {author.title}
+                  </span>
+                )}
               </li>
             ))}
           </ul>
@@ -105,6 +114,7 @@ TopicContentListing.propTypes = {
       id: PropTypes.number,
       type: PropTypes.string,
       value: PropTypes.any,
+      is_external_profile: PropTypes.bool,
     })),
     contentsubtype: PropTypes.string,
     contenttype: PropTypes.string,

--- a/cigionline/static/pages/multimedia_page/css/multimedia_page.scss
+++ b/cigionline/static/pages/multimedia_page/css/multimedia_page.scss
@@ -83,6 +83,7 @@ section {
           font-size: 0.75em;
           margin: 0;
           text-transform: uppercase;
+          color: $cigi-text-grey;
         }
 
         .date {

--- a/cigionline/static/themes/cyber_series/css/includes/_in_the_series.scss
+++ b/cigionline/static/themes/cyber_series/css/includes/_in_the_series.scss
@@ -105,6 +105,7 @@
         span {
           @include link($color: $cyber-series-primary-colour, $hover-color: $cyber-series-primary-colour);
           @include slash-separated($color: $cyber-series-primary-colour);
+          color: $cyber-series-primary-colour;
         }
       }
     }

--- a/cigionline/static/themes/four_domains_series/css/includes/_in_the_series.scss
+++ b/cigionline/static/themes/four_domains_series/css/includes/_in_the_series.scss
@@ -93,6 +93,7 @@
           $hover-color: $cigi-primary-colour
         );
         margin-top: 0.5em;
+        color: $cigi-text-grey;
       }
     }
 

--- a/cigionline/static/themes/indigenous_lands_series/css/includes/_in_the_series.scss
+++ b/cigionline/static/themes/indigenous_lands_series/css/includes/_in_the_series.scss
@@ -30,6 +30,7 @@
         span {
           @include comma-separated;
           @include link($color: $cigi-medium-grey, $hover-color: $cigi-primary-colour);
+          color: $cigi-medium-grey;
         }
       }
     }

--- a/cigionline/static/themes/innovation_series/css/_innovation_series_article.scss
+++ b/cigionline/static/themes/innovation_series/css/_innovation_series_article.scss
@@ -41,6 +41,7 @@
 
         .author {
           @include link($color: $cigi-dark-grey, $hover-color: $cigi-primary-colour);
+          color: $cigi-dark-grey;
         }
       }
 

--- a/cigionline/static/themes/john_holmes_series/css/_john_holmes_series_article_series.scss
+++ b/cigionline/static/themes/john_holmes_series/css/_john_holmes_series_article_series.scss
@@ -202,6 +202,7 @@
               $color: $cigi-text-grey,
               $hover-color: $cigi-primary-colour
             );
+            color: $cigi-text-grey;
             margin: 0;
             text-align: right;
             text-transform: uppercase;

--- a/cigionline/static/themes/pfpc_series/css/_pfpc_series_article.scss
+++ b/cigionline/static/themes/pfpc_series/css/_pfpc_series_article.scss
@@ -107,8 +107,10 @@
     .authors {
       @include media-breakpoint-up(md) {
         @include link($color: $white !important, $hover-color: $cigi-dark-pink !important);
+        color: $white;
       }
       @include link($color: $black, $hover-color: $cigi-dark-pink);
+      color: $black;
       font-weight: 600;
       justify-content: center;
       margin-bottom: 0;

--- a/cigionline/static/themes/platform_governance_series/css/_platform_governance_series_article.scss
+++ b/cigionline/static/themes/platform_governance_series/css/_platform_governance_series_article.scss
@@ -233,6 +233,7 @@
         @include media-breakpoint-up(md) {
           font-size: 1.3em;
         }
+        color: $white;
         display: block;
         font-size: 1;
         margin: 0;

--- a/cigionline/static/themes/platform_governance_series/css/_platform_governance_series_article_series.scss
+++ b/cigionline/static/themes/platform_governance_series/css/_platform_governance_series_article_series.scss
@@ -309,6 +309,7 @@
 
           span {
             @include comma-separated;
+            color: $platform-governance-series-authors-grey;
           }
         }
 

--- a/cigionline/static/themes/space_series/css/_article_page.scss
+++ b/cigionline/static/themes/space_series/css/_article_page.scss
@@ -158,6 +158,7 @@
         $hover-color: $cigi-primary-colour
       );
       font-family: $font-family-base;
+      color: $cigi-text-grey;
     }
 
     &.sticky {

--- a/cigionline/static/themes/space_series/css/_article_series_page.scss
+++ b/cigionline/static/themes/space_series/css/_article_series_page.scss
@@ -227,6 +227,10 @@ body {
                       color: $cigi-medium-grey;
                       margin-right: 0.2em;
                     }
+
+                    span {
+                      color: $cigi-medium-grey;
+                    }
                   }
                 }
               }

--- a/cigionline/static/themes/space_series/css/_multimedia_page.scss
+++ b/cigionline/static/themes/space_series/css/_multimedia_page.scss
@@ -167,6 +167,10 @@
         $hover-color: $cigi-primary-colour
       );
       font-family: $font-family-base;
+
+      span {
+        color: $cigi-text-grey;
+      }
     }
 
     .in-the-series-expand {

--- a/cigionline/static/themes/wto_series/css/includes/_in_the_series.scss
+++ b/cigionline/static/themes/wto_series/css/includes/_in_the_series.scss
@@ -43,6 +43,7 @@
 
     .authors {
       @include link($color: $black, $hover-color: $black);
+      color: $black;
       font-size: 0.8em;
       margin: 0;
       text-transform: uppercase;

--- a/people/models.py
+++ b/people/models.py
@@ -315,6 +315,10 @@ class PersonPage(
             return snippet[:350] if len(snippet) > 350 else snippet
         else:
             return snippet
+    
+    @property
+    def is_external_profile(self):
+        return self.person_types.filter(name='External profile').exists()
 
     content_panels = Page.content_panels + [
         MultiFieldPanel(

--- a/people/models.py
+++ b/people/models.py
@@ -315,7 +315,7 @@ class PersonPage(
             return snippet[:350] if len(snippet) > 350 else snippet
         else:
             return snippet
-    
+
     @property
     def is_external_profile(self):
         return self.person_types.filter(name='External profile').exists()

--- a/people/tests.py
+++ b/people/tests.py
@@ -53,7 +53,7 @@ class PeoplePageTests(WagtailPageTestCase):
 
 class PersonListPageBasicTests(WagtailPageTestCase):
     fixtures = ["people.json"]
-    
+
     def setUp(self):
         self.superuser = User.objects.create_superuser(
             username='testsuperuser',

--- a/people/tests.py
+++ b/people/tests.py
@@ -1,4 +1,5 @@
 from core.models import BasicPage
+from django.contrib.auth.models import User
 from home.models import HomePage
 from wagtail.test.utils import WagtailPageTestCase
 from wagtail.test.utils.form_data import nested_form_data, rich_text
@@ -7,6 +8,14 @@ from .models import PeoplePage, PersonListPage, PersonPage
 
 
 class PeoplePageTests(WagtailPageTestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username='testsuperuser',
+            email='testsuperuser@example.com',
+            password='testpassword'
+        )
+        self.client.login(username='testsuperuser', password='testpassword')
+
     def test_peoplepage_parent_page_types(self):
         self.assertAllowedParentPageTypes(
             PeoplePage,
@@ -36,7 +45,7 @@ class PeoplePageTests(WagtailPageTestCase):
             }))
             self.fail('Expected to error')
         except AssertionError as ae:
-            if str(ae) == "Creating a page people.peoplepage didn't redirect the user to the explorer, but to [(\'/admin/\', 302)]":
+            if str(ae) == "Creating a page people.peoplepage didn't redirect the user to the expected page /admin/pages/3/, but to [(\'/admin/\', 302)]":
                 pass
             else:
                 raise ae
@@ -44,6 +53,14 @@ class PeoplePageTests(WagtailPageTestCase):
 
 class PersonListPageBasicTests(WagtailPageTestCase):
     fixtures = ["people.json"]
+    
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username='testsuperuser',
+            email='testsuperuser@example.com',
+            password='testpassword'
+        )
+        self.client.login(username='testsuperuser', password='testpassword')
 
     def test_personlistpage_parent_page_types(self):
         self.assertAllowedParentPageTypes(
@@ -66,7 +83,7 @@ class PersonListPageBasicTests(WagtailPageTestCase):
             }))
             self.fail('Expected to error')
         except AssertionError as ae:
-            if str(ae) == "Creating a page people.personlistpage didn't redirect the user to the explorer, but to [(\'/admin/\', 302)]":
+            if str(ae) == "Creating a page people.personlistpage didn't redirect the user to the expected page /admin/pages/3/, but to [(\'/admin/\', 302)]":
                 pass
             else:
                 raise ae

--- a/people/wagtail_hooks.py
+++ b/people/wagtail_hooks.py
@@ -56,15 +56,17 @@ class PersonModelAdminGroup(ModelAdminGroup):
 
 modeladmin_register(PersonModelAdminGroup)
 
+
 def set_personpage_privacy(request, page):
     if isinstance(page, PersonPage):
         if page.person_types.filter(name='External profile').exists():
             PageViewRestriction.objects.create(page=page, restriction_type=PageViewRestriction.LOGIN)
-            
-            
+
+
 @hooks.register('after_create_page')
 def after_create_page(request, page):
     set_personpage_privacy(request, page)
+
 
 @hooks.register('after_edit_page')
 def after_edit_page(request, page):

--- a/people/wagtail_hooks.py
+++ b/people/wagtail_hooks.py
@@ -7,6 +7,7 @@ from wagtail.contrib.modeladmin.options import (
     modeladmin_register,
 )
 from wagtail import hooks
+from wagtail.models import PageViewRestriction
 
 from .models import PersonListPage, PersonPage
 
@@ -54,3 +55,17 @@ class PersonModelAdminGroup(ModelAdminGroup):
 
 
 modeladmin_register(PersonModelAdminGroup)
+
+def set_personpage_privacy(request, page):
+    if isinstance(page, PersonPage):
+        if page.person_types.filter(name='External profile').exists():
+            PageViewRestriction.objects.create(page=page, restriction_type=PageViewRestriction.LOGIN)
+            
+            
+@hooks.register('after_create_page')
+def after_create_page(request, page):
+    set_personpage_privacy(request, page)
+
+@hooks.register('after_edit_page')
+def after_edit_page(request, page):
+    set_personpage_privacy(request, page)

--- a/research/tests.py
+++ b/research/tests.py
@@ -1,4 +1,5 @@
 from core.models import BasicPage
+from django.contrib.auth.models import User
 from home.models import HomePage
 from django.template import Context, Template
 from wagtail.test.utils import WagtailPageTestCase
@@ -56,6 +57,14 @@ class ResearchLandingPageTests(WagtailPageTestCase):
 
 
 class TopicListPageTests(WagtailPageTestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username='testsuperuser',
+            email='testsuperuser@example.com',
+            password='testpassword'
+        )
+        self.client.login(username='testsuperuser', password='testpassword')
+
     def test_topiclistpage_parent_page_types(self):
         """
         Verify allowed parent page types.
@@ -99,7 +108,7 @@ class TopicListPageTests(WagtailPageTestCase):
             }))
             self.fail('Expected to error')
         except AssertionError as ae:
-            if str(ae) == "Creating a page research.topiclistpage didn't redirect the user to the explorer, but to [(\'/admin/\', 302)]":
+            if str(ae) == "Creating a page research.topiclistpage didn't redirect the user to the expected page /admin/pages/3/, but to [(\'/admin/\', 302)]":
                 pass
             else:
                 raise ae

--- a/search/views.py
+++ b/search/views.py
@@ -26,6 +26,7 @@ def process_item(page, request):
                     'id': author.author.id,
                     'title': author.author.title,
                     'url': author.author.url,
+                    'is_external_profile': author.author.is_external_profile,
                 } for author in page.specific.authors.all()]
             elif field == 'cigi_people_mentioned':
                 item['cigi_people_mentioned'] = [{

--- a/search/views.py
+++ b/search/views.py
@@ -33,6 +33,7 @@ def process_item(page, request):
                     'id': person.person.id,
                     'title': person.person.title,
                     'url': person.person.url,
+                    'is_external_profile': person.person.is_external_profile,
                 } for person in page.specific.cigi_people_mentioned.all()]
             elif field == 'topics':
                 item['topics'] = [{

--- a/signals/apps.py
+++ b/signals/apps.py
@@ -21,7 +21,7 @@ class InstanceInfo():
         self.content_type = 'Articles' if instance.contenttype == 'Opinion' else instance.contenttype  # adjust ContentPage.contenttype to match page_type
         self.publisher = f'{instance.get_latest_revision().user.first_name} {instance.get_latest_revision().user.last_name}'
         self.relative_url = instance.get_url_parts()[-1]  # last item in the tuple is the relative url to root; e.g. /articles/an-article/
-    
+
 
 class NotificationFlags(InstanceInfo):
     def __init__(self, instance):

--- a/templates/includes/about_the_author.html
+++ b/templates/includes/about_the_author.html
@@ -13,7 +13,11 @@
           {% endif %}
           <div class="author-block">
             <div class="name">
-              <a href="{% pageurl person %}">{{ person.title }}</a>
+              {% if person.is_external_profile %}
+                {{ person.title }}
+              {% else %}
+                <a href="{% pageurl person %}">{{ person.title }}</a>
+              {% endif %}
             </div>
             {% if not item.hide_link and person.short_bio|length > 1 and not person.archive %}
               {{ person.short_bio|richtext }}

--- a/templates/includes/authors.html
+++ b/templates/includes/authors.html
@@ -8,7 +8,7 @@
       {% elif item.editor %}
         {% define item.editor as person %}
       {% endif %}
-      {% if item.hide_link or hide_link %}
+      {% if item.hide_link or hide_link or person.is_external_profile %}
         <span class="block-author">{{ person.title }}</span>
       {% else %}
         <a class="block-author" href="{% pageurl person %}">{{ person.title }}</a>

--- a/templates/includes/features/feature_content_people.html
+++ b/templates/includes/features/feature_content_people.html
@@ -12,7 +12,7 @@
           {% define item as person %}
         {% endif %}
         {% if person %}
-          {% if item.hide_link %}
+          {% if item.hide_link or item.author.is_external_profile %}
             <li>{{ person.title }}</li>
           {% else %}
             <li><a href="{% pageurl person %}">{{ person.title }}</a></li>

--- a/templates/includes/heroes/hero_event.html
+++ b/templates/includes/heroes/hero_event.html
@@ -41,7 +41,7 @@
             Speaker{{ author_count|pluralize }}:
             <ul class="custom-text-list">
               {% for item in authors %}
-                {% if item.hide_link %}
+                {% if item.hide_link or item.author.is_external_profile %}
                   <li class="block-speaker">{{ item.author.title }}</li>
                 {% else %}
                   <li class="block-speaker"><a href="{% pageurl item.author %}">{{ item.author.title }}</a></li>

--- a/templates/includes/heroes/hero_multimedia.html
+++ b/templates/includes/heroes/hero_multimedia.html
@@ -14,7 +14,7 @@
           <p class="mm-meta">
             Speaker{{ self.author_count|pluralize }}:
             {% for item in self.authors.all %}
-              {% if item.hide_link %}
+              {% if item.hide_link or item.author.is_external_profile %}
                 <span>{{ item.author.title }}</span>
               {% else %}
                 <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/includes/swiper.html
+++ b/templates/includes/swiper.html
@@ -22,7 +22,13 @@
               <h4>CONTRIBUTORS</h4>
               <ul class="contributors">
                 {% for contributor in item.series_authors %}
-                  <li><a href="{% pageurl contributor %}">{{ contributor.title }}</a></li>
+                  <li>
+                    {% if contributor.is_external_profile %}
+                      <span>{{ contributor.title }}</span>
+                    {% else %}
+                      <a href="{% pageurl contributor %}">{{ contributor.title }}</a>
+                    {% endif %}
+                  </li>
                 {% endfor %}
               </ul>
             </div>

--- a/templates/themes/after_covid_series/article_series_page.html
+++ b/templates/themes/after_covid_series/article_series_page.html
@@ -88,7 +88,7 @@
                 </h3>
                 <p class="authors">
                   {% for item in series_item.content_page.authors.all %}
-                    {% if item.hide_link %}
+                    {% if item.hide_link or item.author.is_external_profile %}
                       <span>{{ item.author.title }}</span>
                     {% else %}
                       <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/ai_ethics_series/article_series_page.html
+++ b/templates/themes/ai_ethics_series/article_series_page.html
@@ -102,7 +102,13 @@
               </div>
               <ul class="authors">
                 {% for item in page.authors.all %}
-                  <li><a href="{% pageurl item.author %}"> {{ item.author.title }}</a></li>
+                  <li>
+                    {% if item.hide_link or item.author.is_external_profile %}
+                      <span> {{ item.author.title }}</span>
+                    {% else %}
+                      <a href="{% pageurl item.author %}"> {{ item.author.title }}</a>
+                    {% endif %}
+                  </li>
                 {% endfor %}
               </ul>
               {% endwith %}

--- a/templates/themes/ai_series/article_series_page.html
+++ b/templates/themes/ai_series/article_series_page.html
@@ -101,7 +101,7 @@
                 {% endif %}
                 <ul class="authors">
                   {% for item in series_item.content_page.authors.all %}
-                    {% if item.hide_link %}
+                    {% if item.hide_link or item.author.is_external_profile %}
                       <li>{{ item.author.title }}</li>
                     {% else %}
                       <li><a href="{% pageurl item.author %}">{{ item.author.title }}</a></li>

--- a/templates/themes/cyber_series/article_series_page.html
+++ b/templates/themes/cyber_series/article_series_page.html
@@ -83,7 +83,7 @@
               </h3>
               <p class="authors">
                 {% for item in series_item.content_page.authors.all %}
-                  {% if item.hide_link %}
+                  {% if item.hide_link or item.author.is_external_profile %}
                     <span>{{ item.author.title }}</span>
                   {% else %}
                     <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/cyber_series/includes/in_the_series.html
+++ b/templates/themes/cyber_series/includes/in_the_series.html
@@ -29,7 +29,7 @@
             </h5>
             <p class="authors">
               {% for item in series_item.content_page.authors.all %}
-                {% if item.hide_link %}
+                {% if item.hide_link or item.author.is_external_profile %}
                   <span>{{ item.author.title }}</span>
                 {% else %}
                   <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/data_series/article_page.html
+++ b/templates/themes/data_series/article_page.html
@@ -80,7 +80,7 @@
             Author{{self.author_count|pluralize}}:
 
             {% for item in self.authors.all %}
-              {% if item.hide_link %}
+              {% if item.hide_link or item.author.is_external_profile %}
                 <span class="author">{{ item.author.title }}</span>
               {% else %}
                 <span class="author"><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/data_series/article_series_page.html
+++ b/templates/themes/data_series/article_series_page.html
@@ -80,7 +80,7 @@
                 <h4 class="article-title"><a href="{% pageurl series_item.content_page %}">{{ series_item.content_page.title}}</a></h4>
                 <p class="authors">
                   {% for item in series_item.content_page.authors.all %}
-                    {% if item.hide_link %}
+                    {% if item.hide_link or item.author.is_external_profile %}
                       <span>{{ item.author.title }}</span>
                     {% else %}
                       <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/data_series/includes/in_the_series.html
+++ b/templates/themes/data_series/includes/in_the_series.html
@@ -24,7 +24,7 @@
             <h5 class="article-title"><a href="{% pageurl series_item.content_page %}">{{ series_item.content_page.title }}</a></h5>
             <p class="authors">
               {% for item in series_item.content_page.authors.all %}
-                {% if item.hide_link %}
+                {% if item.hide_link or item.author.is_external_profile %}
                   <span>{{ item.author.title }}</span>
                 {% else %}
                   <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/health_security_series/article_series_page.html
+++ b/templates/themes/health_security_series/article_series_page.html
@@ -91,7 +91,7 @@
                 </h3>
                 <p class="authors">
                   {% for item in series_item.content_page.authors.all %}
-                    {% if item.hide_link %}
+                    {% if item.hide_link or item.author.is_external_profile %}
                       <span>{{ item.author.title }}</span>
                     {% else %}
                       <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/indigenous_lands_series/article_page.html
+++ b/templates/themes/indigenous_lands_series/article_page.html
@@ -22,7 +22,7 @@
             <div class="authors"><label>Author{{ self.author_count|pluralize }}:</label>
               <div class="custom-text-list">
                 {% for item in self.authors.all %}
-                  {% if item.hide_link %}
+                  {% if item.hide_link or item.author.is_external_profile %}
                     <span class="block-author">{{ item.author.title }}</span>
                   {% else %}
                     <a class="block-author" href="{% pageurl item.author %}">{{ item.author.title }}</a>

--- a/templates/themes/indigenous_lands_series/includes/in_the_series.html
+++ b/templates/themes/indigenous_lands_series/includes/in_the_series.html
@@ -14,7 +14,7 @@
           <p class="authors meta">
             Author{{ series_item.content_page.author_count|pluralize }}:
             {% for item in series_item.content_page.authors.all %}
-              {% if item.hide_link %}
+              {% if item.hide_link or item.author.is_external_profile %}
                 <span>{{ item.author.title }}</span>
               {% else %}
                 <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/indigenous_lands_series/includes/in_the_series.html
+++ b/templates/themes/indigenous_lands_series/includes/in_the_series.html
@@ -15,7 +15,7 @@
             Author{{ series_item.content_page.author_count|pluralize }}:
             {% for item in series_item.content_page.authors.all %}
               {% if item.hide_link or item.author.is_external_profile %}
-                <span>{{ item.author.title }}</span>
+                <span>{{ item.author.title.strip }}</span>
               {% else %}
                 <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>
               {% endif %}

--- a/templates/themes/innovation_series/article_page.html
+++ b/templates/themes/innovation_series/article_page.html
@@ -24,7 +24,7 @@
               Author{{ self.author_count|pluralize }}:
               {% for item in self.authors.all %}
                 {% if item.hide_link or item.author.is_external_profile %}
-                  <span>{{ item.author.title }}</span>
+                  <span class="author">{{ item.author.title }}</span>
                 {% else %}
                   <span class="author"><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>
                 {% endif %}

--- a/templates/themes/innovation_series/article_page.html
+++ b/templates/themes/innovation_series/article_page.html
@@ -23,7 +23,7 @@
             <p>
               Author{{ self.author_count|pluralize }}:
               {% for item in self.authors.all %}
-                {% if item.hide_link %}
+                {% if item.hide_link or item.author.is_external_profile %}
                   <span>{{ item.author.title }}</span>
                 {% else %}
                   <span class="author"><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/innovation_series/article_series_page.html
+++ b/templates/themes/innovation_series/article_series_page.html
@@ -88,7 +88,7 @@
                       <div class="innovation-series-article-series-featured-item-content">
                         <p class="featured-item-authors">
                           {% for item in featured_item.value.specific.authors.all %}
-                            {% if item.hide_link %}
+                            {% if item.hide_link or item.author.is_external_profile %}
                               <span>{{ item.author.title }}</span>
                             {% else %}
                               <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>
@@ -154,7 +154,7 @@
                   <p class="authors">
                     {% if series_item.content_page.specific|page_type == 'multimedia' %}Speaker{% else %}Author{% endif %}{{ block.value.specific.author_count|pluralize }}:
                     {% for item in series_item.content_page.authors.all %}
-                      {% if item.hide_link %}
+                      {% if item.hide_link or item.author.is_external_profile %}
                         <span>{{ item.author.title }}</span>
                       {% else %}
                         <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/innovation_series/includes/in_the_series.html
+++ b/templates/themes/innovation_series/includes/in_the_series.html
@@ -44,7 +44,7 @@
                   <p class="authors">
                     {% if series_item.content_page.specific|page_type == 'multimedia' %}Speaker{% else %}Author{% endif %}{{ series_item.content_page.author_count|pluralize }}:
                     {% for item in series_item.content_page.authors.all %}
-                      {% if item.hide_link %}
+                      {% if item.hide_link or item.author.is_external_profile %}
                         <span>{{ item.author.title }}</span>
                       {% else %}
                         <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/longform/article_page.html
+++ b/templates/themes/longform/article_page.html
@@ -30,7 +30,7 @@
           <p>
             Author{{self.author_count|pluralize}}:
             {% for item in self.authors.all %}
-              {% if item.hide_link %}
+              {% if item.hide_link or item.author.is_external_profile %}
                 <span class="author">{{ item.author.title }}</span>
               {% else %}
                 <span class="author"><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>
@@ -86,7 +86,7 @@
                       <p class="authors">
                         Author{{ series_item.content_page.author_count|pluralize }}:
                         {% for item in series_item.content_page.authors.all %}
-                          {% if item.hide_link %}
+                          {% if item.hide_link or item.author.is_external_profile %}
                             <span>{{ item.author.title }}</span>
                           {% else %}
                             <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/longform/article_series_page.html
+++ b/templates/themes/longform/article_series_page.html
@@ -89,7 +89,7 @@
                         <h3><a href="{{ featured_item.value.url }}">{{ featured_item.value.title }}</a></h3>
                         <p class="featured-item-authors">
                           {% for item in featured_item.value.specific.authors.all %}
-                            {% if item.hide_link %}
+                            {% if item.hide_link or item.author.is_external_profile %}
                               <span>{{ item.author.title }}</span>
                             {% else %}
                               <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>
@@ -140,7 +140,7 @@
                 <p class="authors">
                   Author{{ series_item.content_page.author_count|pluralize }}:
                   {% for item in series_item.content_page.authors.all %}
-                    {% if item.hide_link %}
+                    {% if item.hide_link or item.author.is_external_profile %}
                       <span>{{ item.author.title }}</span>
                     {% else %}
                       <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/pfpc_series/article_series_page.html
+++ b/templates/themes/pfpc_series/article_series_page.html
@@ -102,7 +102,7 @@
                 </h3>
                 <p class="authors">
                   {% for item in series_item.content_page.authors.all %}
-                    {% if item.hide_link %}
+                    {% if item.hide_link or item.author.is_external_profile %}
                       <span>{{ item.author.title }}</span>
                     {% else %}
                       <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/platform_governance_series/article_page.html
+++ b/templates/themes/platform_governance_series/article_page.html
@@ -82,7 +82,7 @@
                   </h3>
                   <p class="authors">
                     {% for item in series_item.content_page.authors.all %}
-                      {% if item.hide_link %}
+                      {% if item.hide_link or item.author.is_external_profile %}
                         <span>{{ item.author.title }}<span>
                       {% else %}
                         <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/platform_governance_series/article_series_page.html
+++ b/templates/themes/platform_governance_series/article_series_page.html
@@ -114,7 +114,7 @@
                 </h3>
                 <p class="authors">
                   {% for item in series_item.content_page.authors.all %}
-                    {% if item.hide_link %}
+                    {% if item.hide_link or item.author.is_external_profile %}
                       <span>{{ item.author.title }}</span>
                     {% else %}
                       <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/women_and_trade_series/article_page.html
+++ b/templates/themes/women_and_trade_series/article_page.html
@@ -21,7 +21,7 @@
           <div class="authors"><label>Author{{ self.author_count|pluralize }}:</label>
             <div class="custom-text-list">
               {% for item in self.authors.all %}
-                {% if item.hide_link %}
+                {% if item.hide_link or item.author.is_external_profile %}
                   <span class="block-author">{{ item.author.title }}</span>
                 {% else %}
                   <a class="block-author" href="{% pageurl item.author %}">{{ item.author.title }}</a>

--- a/templates/themes/women_and_trade_series/includes/in_the_series.html
+++ b/templates/themes/women_and_trade_series/includes/in_the_series.html
@@ -13,7 +13,7 @@
         <div class="authors">
           <label>Author{{ series_item.content_page.author_count|pluralize }}:</label>
           {% for item in series_item.content_page.authors.all %}
-            {% if item.hide_link %}
+            {% if item.hide_link or item.author.is_external_profile %}
               <span>{{ item.author.title }}</span>
             {% else %}
               <span><a href="{% pageurl item.author %}">{{ item.author.title }}</a></span>

--- a/templates/themes/wto_series/includes/in_the_series.html
+++ b/templates/themes/wto_series/includes/in_the_series.html
@@ -39,7 +39,7 @@
             </h4>
             <ul class="authors">
               {% for item in series_item.content_page.authors.all %}
-                {% if item.hide_link %}
+                {% if item.hide_link or item.author.is_external_profile %}
                   <li>{{ item.author.title }}</li>
                 {% else %}
                   <li><a href="{% pageurl item.author %}">{{ item.author.title }}</a></li>


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#923

- Implemented hook to automatically change privacy settings of any PersonPage tagged as external profile to LOGIN
- Do not render links to external profile PersonPages


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
