### PR TITLE
CIGI-980b: filter out topics with 0 count in research landing and footer

### DIFF
--- a/research/templatetags/topic_tags.py
+++ b/research/templatetags/topic_tags.py
@@ -8,6 +8,7 @@ register = template.Library()
 @register.inclusion_tag('research/highlighted_topics.html', takes_context=True)
 def highlighted_topics(context):
     highlighted_topics = TopicPage.objects.live().filter(archive=0).order_by('title').annotate(count=Count('content_pages'))
+    highlighted_topics = highlighted_topics.filter(count__gt=0)
     result = {
         'highlighted_topics': highlighted_topics,
     }


### PR DESCRIPTION
- update research page and footer to exclude topics with 0 count from being displayed