### PR TITLE
CIGI-982b: make large feature slot poster gif compatible

### DIFF
--- a/templates/includes/features/feature_content_large.html
+++ b/templates/includes/features/feature_content_large.html
@@ -8,7 +8,11 @@
   <a href="{% if content.feature_url %}{{ content.feature_url }}{% else %}{% pageurl content %}{% endif %}" class="feature-content-image">
     <div class="img-wrapper">
       {% if poster %}
-        {% image content.image_poster original %}
+        {% if content.image_poster.file.url|file_extension == '.gif' %}
+          <img src="{{content.image_poster.file.url}}" alt="{{content.image_poster.caption}}" />
+        {% else %}
+          {% image content.image_poster original %}
+        {% endif %}
       {% else %}
         {% if content.image_feature %}
           {% define content.image_feature as feature_image %}


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#982

Specifically for allowing the FoT program page featured section to use gif as poster image, but change is on all large feature slots.


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [ ] Have you reviewed your own code changes?
- [ ] Has the issue owner reviewed your changes?
- [ ] Have you given the PR a descriptive title?
- [ ] Have you described your changes above? Always include screenshots if applicable.
- [ ] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
