### PR TITLE
CIGI-986: Move essay article type back to articles directory

### DIFF
--- a/cigionline/settings/base.py
+++ b/cigionline/settings/base.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     'wagtail.contrib.forms',
     'wagtail.contrib.modeladmin',
     'wagtail.contrib.redirects',
+    'wagtail.contrib.routable_page',
     'wagtail.contrib.table_block',
     'wagtail.contrib.styleguide',
     'wagtail.embeds',

--- a/templates/includes/heroes/hero_standard.html
+++ b/templates/includes/heroes/hero_standard.html
@@ -48,7 +48,7 @@
                 {% for submenu_item in submenu_items %}
                   {% if submenu_item.link_page %}
                     <li>
-                      {% if submenu_item.link_page.url_path == request.path or submenu_item.link_url == request.path  %}
+                      {% if submenu_item.link_page.url_path == self.url_path or submenu_item.link_url == request.path  %}
                         {{ submenu_item.title }}
                       {% else %}
                         <a href="

--- a/templates/includes/heroes/hero_standard.html
+++ b/templates/includes/heroes/hero_standard.html
@@ -48,10 +48,16 @@
                 {% for submenu_item in submenu_items %}
                   {% if submenu_item.link_page %}
                     <li>
-                      {% if submenu_item.link_page.url_path == self.url_path %}
+                      {% if submenu_item.link_page.url_path == request.path or submenu_item.link_url == request.path  %}
                         {{ submenu_item.title }}
                       {% else %}
-                        <a href="{% pageurl submenu_item.link_page %}">
+                        <a href="
+                          {% if submenu_item.link_url %}
+                            {{ submenu_item.link_url }}
+                          {% else %}
+                            {% pageurl submenu_item.link_page %}
+                          {% endif %}
+                        ">
                           {{ submenu_item.title }}
                         </a>
                       {% endif %}


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#986

- Add custom route to route /publications/essays to essays article type page
- Modify hero standard template to accomodate custom route
- To test: 
  - move essay article type page back to /articles/
  - rename it to "Essays"
  - add essays to the publications menu if it's not there already, and add /publications/essays/ to the link_url field

Staged on staging site 2

#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
