### PR TITLE
CIGI-1074: Fix all_staff endpoint not requesting all staff members

### DIFF
--- a/people/views.py
+++ b/people/views.py
@@ -95,7 +95,7 @@ def all_staff(request):
             'title': person.title,
             'url': person.get_url(request),
             'has_bio': False if not person.body else True,
-        } for person in staff[:50]]
+        } for person in staff]
     })
 
 


### PR DESCRIPTION
#### Description of changes
resolves CIGIHub/cigi-tickets#1074

- all_staff endpoint was built to only return the first 50 staff. Updated it to return all staff


#### Pull Request checklist
This checklist needs to be completed before assigning reviewers. If the checklist will not be completed, please comment with the reason.
- [x] Have you reviewed your own code changes?
- [x] Has the issue owner reviewed your changes?
- [x] Have you given the PR a descriptive title?
- [x] Have you described your changes above? Always include screenshots if applicable.
- [x] Have you pushed your latest commit to this branch?

---
#### Code Review checklist
This checklist should be completed if applicable before approving the pull request.
- [ ] Have you reviewed the code changes?
- [ ] Have you tested the changes on Google Chrome?
- [ ] Have you tested the changes on Safari?
- [ ] Have you tested the changes on Microsoft Edge (non-Chromium)?
- [ ] Have you tested the changes on iOS?
- [ ] Have you tested the changes on Android?
