### PR TITLE
CIGI-1176: Add download button to policy prompt episode page footer

### DIFF
--- a/cigionline/static/themes/policy_prompt/css/_footer.scss
+++ b/cigionline/static/themes/policy_prompt/css/_footer.scss
@@ -52,6 +52,7 @@ footer {
       @include media-breakpoint-up(md) {
         margin-top: 0;
         max-width: 400px;
+        text-align: left;
       }
       margin-top: 2em;
 
@@ -93,6 +94,33 @@ footer {
       }
     }
 
+    .download-episode {
+      align-items: center;
+      border: 1px solid $white;
+      color: $white;
+      display: inline-flex;
+      font-family: $policy-prompt-font;
+      font-size: 0.6rem;
+      font-weight: 600;
+      letter-spacing: 1px;
+      line-height: 1;
+      margin-bottom: 1rem;
+      padding: 0.7rem 0.8rem;
+      text-transform: uppercase;
+      transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+
+      i {
+        margin-right: 0.5rem;
+      }
+
+      &:hover {
+        background-color: $policy-prompt-green;
+        border-color: $policy-prompt-green;
+        color: $black;
+        text-decoration: none;
+      }
+    }
+
     .spacer {
       @include media-breakpoint-up(md) {
         display: block;
@@ -103,7 +131,7 @@ footer {
       .slash {
         @include slash($height: 50px, $color: $white);
         @include media-breakpoint-up(md) {
-          height: 150px;
+          height: 175px;
           margin: 0 1rem;
         }
         @include media-breakpoint-up(lg) {
@@ -124,7 +152,7 @@ footer {
 
       a {
         display: block;
-        margin-left: 2em;
+        margin-left: 1em;
         width: 25px;
 
         &:hover {
@@ -153,6 +181,7 @@ footer {
         letter-spacing: 0.1em;
         font-style: normal;
         margin: 0;
+        line-height: 1;
         text-transform: uppercase;
       }
     }

--- a/templates/themes/policy_prompt/includes/footer.html
+++ b/templates/themes/policy_prompt/includes/footer.html
@@ -35,6 +35,12 @@
               </a>
             {% endfor %}
           </div>
+          {% if episode_download_url %}
+            <a class="download-episode" href="{{ episode_download_url }}" download>
+              <i class="fa-solid fa-download" aria-hidden="true"></i>
+              <span>Download Episode</span>
+            </a>
+          {% endif %}
           <p>
             Policy Prompt <em>is produced by the Centre for International Governance Innovation.</em>
           </p>

--- a/templates/themes/policy_prompt/multimedia_page.html
+++ b/templates/themes/policy_prompt/multimedia_page.html
@@ -327,5 +327,6 @@
 {% endblock content %}
 
 {% block footer %}
-  {% include "./includes/footer.html" with podcast_subscribe_buttons=self.multimedia_series.specific.podcast_subscribe_buttons live=self.multimedia_series.specific.podcast_live %}
+  {% firstof self.podcast_audio_url self.multimedia_url as episode_download_url %}
+  {% include "./includes/footer.html" with podcast_subscribe_buttons=self.multimedia_series.specific.podcast_subscribe_buttons live=self.multimedia_series.specific.podcast_live episode_download_url=episode_download_url %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Added download button to Policy Prompt episode pages

resolves CIGIHub/cigi-tickets#1176
Fixes/Refs:

## Review Notes

<!-- Point reviewers at the risky or important bits: migrations, data changes, Wagtail/admin behavior, templates, email/reporting flows, frontend states, or anything AI touched heavily. -->

## AI Assistance

<!-- Keep this practical: mention AI-generated/refactored/reviewed areas only when it helps the reviewer know where to look closer. -->

- [ ] No AI assistance used
- [x] AI helped with code, tests, refactoring, debugging, or review
- [x] I reviewed the AI-assisted changes before requesting review

Notes:

## Screenshots / Output

<img width="835" height="303" alt="image" src="https://github.com/user-attachments/assets/79ff8435-641c-4270-8af7-30d2cf74a3fd" />

