### PR TITLE
CIGI-1177: Implement admin purge Cloudflare cache functionality

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,6 @@
+from django import forms
+from django.utils import timezone
+from articles.models import ArticleListPage, ArticlePage, ArticleTypePage
 from annual_reports.models import AnnualReportListPage
 from careers.models import JobPostingListPage
 from home.models import HomePage, Think7HomePage
@@ -5,18 +8,81 @@ from people.models import PersonListPage
 from research.models import (
     ProjectPage,
 )
+from wagtail.models import Site
 from wagtail.test.utils import WagtailPageTestCase
 
+from .wagtail_hooks import get_filter_purge_cache_urls, get_purge_cache_url
 from .models import (
     BasicPage,
     FacilityRentalsPage,
     FundingPage,
     HumanAnalysisStandardPage,
     PrivacyNoticePage,
+    Theme,
     TwentyFifthPageSingleton,
     TwentiethPage,
     TwentiethPageSingleton,
 )
+
+
+class PurgeCloudflareCacheTests(WagtailPageTestCase):
+    def setUp(self):
+        Site.objects.update(hostname='www.cigionline.org', port=443)
+
+    def test_get_purge_cache_url_accepts_full_urls(self):
+        url = 'https://www.cigionline.org/articles/example/'
+
+        self.assertEqual(get_purge_cache_url(url), url)
+
+    def test_get_purge_cache_url_uses_default_site_for_paths(self):
+        self.assertEqual(
+            get_purge_cache_url('/articles/example/'),
+            'https://www.cigionline.org/articles/example/',
+        )
+
+    def test_get_purge_cache_url_ignores_blank_lines(self):
+        self.assertIsNone(get_purge_cache_url('   '))
+
+    def test_get_purge_cache_url_rejects_invalid_input(self):
+        with self.assertRaises(forms.ValidationError):
+            get_purge_cache_url('articles/example/')
+
+    def test_get_filter_purge_cache_urls_filters_articles_by_theme_and_article_type(self):
+        site = Site.objects.get(is_default_site=True)
+        home_page = HomePage(title='Test Home')
+        site.root_page.add_child(instance=home_page)
+        site.root_page = home_page
+        site.save()
+
+        article_list = ArticleListPage(title='Opinions')
+        home_page.add_child(instance=article_list)
+
+        article_type = ArticleTypePage(title='Op-Eds')
+        article_list.add_child(instance=article_type)
+
+        theme = Theme.objects.create(name='Policy Prompt')
+        matching_article = ArticlePage(
+            title='Matching Article',
+            article_type=article_type,
+            theme=theme,
+            publishing_date=timezone.now(),
+        )
+        article_list.add_child(instance=matching_article)
+
+        other_article = ArticlePage(
+            title='Other Article',
+            article_type=article_type,
+            publishing_date=timezone.now(),
+        )
+        article_list.add_child(instance=other_article)
+
+        urls = get_filter_purge_cache_urls({
+            'page_types': ['articles.ArticlePage'],
+            'themes': [theme],
+            'article_types': [article_type],
+        })
+
+        self.assertEqual(urls, [matching_article.get_full_url()])
 
 
 class BasicPageTests(WagtailPageTestCase):

--- a/core/wagtail_hooks.py
+++ b/core/wagtail_hooks.py
@@ -1,19 +1,343 @@
+from urllib.parse import urlparse
+
+from django import forms
+from django.apps import apps
+from django.conf import settings
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models import F
+from django.shortcuts import render
+from django.urls import path, reverse
 from django.templatetags.static import static
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from wagtail.admin import messages
+from wagtail.admin.auth import permission_required
+from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text.converters.html_to_contentstate import (
     BlockElementHandler,
     InlineStyleElementHandler,
 )
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail.contrib.frontend_cache.utils import purge_urls_from_cache
 from wagtail import hooks
-from wagtail.models import Page
+from wagtail.models import Page, Site
 from .models import Theme, QRCodeScan, QRCodeDocumentScan
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.admin.viewsets.base import ViewSetGroup
 from wagtail.admin.ui.tables import Column
 from utils.admin_utils import title_with_actions
+
+
+PURGE_PAGE_TYPE_OPTIONS = {
+    'articles.ArticlePage': {
+        'label': 'Opinions',
+        'type_field': 'article_type',
+        'form_field': 'article_types',
+    },
+    'publications.PublicationPage': {
+        'label': 'Publications',
+        'type_field': 'publication_type',
+        'form_field': 'publication_types',
+    },
+    'multimedia.MultimediaPage': {
+        'label': 'Multimedia',
+        'type_field': 'multimedia_type',
+        'form_field': 'multimedia_types',
+    },
+    'articles.ArticleSeriesPage': {
+        'label': 'Essay series',
+    },
+    'multimedia.MultimediaSeriesPage': {
+        'label': 'Multimedia series',
+    },
+    'core.BasicPage': {
+        'label': 'Basic pages',
+    },
+}
+
+
+class PurgeCloudflareCacheForm(forms.Form):
+    pages = forms.CharField(
+        label='Pages to purge',
+        help_text='Enter one page URL, path, or Wagtail page ID per line.',
+        widget=forms.Textarea(attrs={'rows': 12}),
+        required=False,
+    )
+    page_types = forms.MultipleChoiceField(
+        label='Page types',
+        choices=[(value, option['label']) for value, option in PURGE_PAGE_TYPE_OPTIONS.items()],
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+    )
+    themes = forms.ModelMultipleChoiceField(
+        label='Themes',
+        queryset=Theme.objects.none(),
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+    )
+    article_types = forms.ModelMultipleChoiceField(
+        label='Article types',
+        queryset=apps.get_model('articles', 'ArticleTypePage').objects.none(),
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+    )
+    publication_types = forms.ModelMultipleChoiceField(
+        label='Publication types',
+        queryset=apps.get_model('publications', 'PublicationTypePage').objects.none(),
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+    )
+    multimedia_types = forms.MultipleChoiceField(
+        label='Multimedia types',
+        choices=[],
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        MultimediaPage = apps.get_model('multimedia', 'MultimediaPage')
+        self.fields['themes'].queryset = Theme.objects.order_by('name')
+        self.fields['article_types'].queryset = apps.get_model('articles', 'ArticleTypePage').objects.live().order_by('title')
+        self.fields['publication_types'].queryset = apps.get_model('publications', 'PublicationTypePage').objects.live().order_by('title')
+        self.fields['multimedia_types'].choices = MultimediaPage._meta.get_field('multimedia_type').choices
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if not cleaned_data.get('pages') and not cleaned_data.get('page_types'):
+            raise forms.ValidationError('Enter page URLs/IDs or choose at least one page type.')
+        return cleaned_data
+
+
+def get_purge_cache_url(item):
+    item = item.strip()
+    if not item:
+        return None
+
+    if item.isdigit():
+        try:
+            return Page.objects.live().get(pk=item).get_full_url()
+        except Page.DoesNotExist:
+            raise forms.ValidationError(f'No live Wagtail page found with ID {item}.')
+
+    parsed = urlparse(item)
+    if parsed.scheme and parsed.netloc:
+        return item
+
+    if item.startswith('/'):
+        return Site.objects.get(is_default_site=True).root_url + item
+
+    raise forms.ValidationError(f'Enter a full URL, path starting with /, or page ID: {item}')
+
+
+def get_filter_purge_cache_urls(cleaned_data):
+    urls, _debug_rows = get_filter_purge_cache_urls_debug(cleaned_data)
+    return urls
+
+
+def debug_sql(queryset):
+    sql, params = queryset.query.sql_with_params()
+    return f'{sql}\n\nparams: {params}'
+
+
+def model_has_field(model, field_name):
+    try:
+        model._meta.get_field(field_name)
+    except FieldDoesNotExist:
+        return False
+    return True
+
+
+def get_page_purge_url(page, site=None):
+    url = page.get_full_url()
+    if url:
+        return url
+
+    site = site or Site.objects.get(is_default_site=True)
+    root_path = site.root_page.url_path
+
+    if page.url_path.startswith(root_path):
+        path = '/' + page.url_path[len(root_path):]
+    else:
+        path = page.url_path
+
+    return site.root_url + path
+
+
+def get_filter_purge_cache_urls_debug(cleaned_data):
+    urls = []
+    debug_rows = []
+    default_site = Site.objects.get(is_default_site=True)
+
+    for page_type in cleaned_data.get('page_types'):
+        options = PURGE_PAGE_TYPE_OPTIONS[page_type]
+        model = apps.get_model(page_type)
+        raw_queryset = model.objects.all()
+        live_queryset = raw_queryset.live()
+        public_queryset = live_queryset.public()
+        queryset = live_queryset
+        row = {
+            'page_type': options['label'],
+            'model': page_type,
+            'filters': [],
+            'raw_count': raw_queryset.count(),
+            'live_count': live_queryset.count(),
+            'public_count': public_queryset.count(),
+            'base_sql': debug_sql(queryset),
+        }
+
+        if cleaned_data.get('themes') and model_has_field(model, 'theme'):
+            themes = list(cleaned_data['themes'])
+            queryset = queryset.filter(theme__in=cleaned_data['themes'])
+            row['filters'].append({
+                'label': 'Themes',
+                'values': [theme.name for theme in themes],
+                'count': queryset.count(),
+                'sql': debug_sql(queryset),
+            })
+
+        form_field = options.get('form_field')
+        type_field = options.get('type_field')
+        if form_field and cleaned_data.get(form_field):
+            values = list(cleaned_data[form_field])
+            queryset = queryset.filter(**{f'{type_field}__in': cleaned_data[form_field]})
+            row['filters'].append({
+                'label': model._meta.get_field(type_field).verbose_name.title(),
+                'values': [str(value) for value in values],
+                'count': queryset.count(),
+                'sql': debug_sql(queryset),
+            })
+
+        pages = list(queryset)
+        page_urls = [get_page_purge_url(page, default_site) for page in pages]
+        page_debug = [
+            {
+                'title': page.title,
+                'url_path': page.url_path,
+                'full_url': page.get_full_url(),
+                'purge_url': url,
+            }
+            for page, url in zip(pages, page_urls)
+        ]
+        row['matched_count'] = len(pages)
+        row['url_count'] = len(page_urls)
+        row['urls'] = page_urls
+        row['pages'] = page_debug
+        row['final_sql'] = debug_sql(queryset)
+        debug_rows.append(row)
+        urls.extend(page_urls)
+
+    return urls, debug_rows
+
+
+@permission_required('wagtailadmin.access_admin')
+def purge_cloudflare_cache_view(request):
+    if request.method == 'POST':
+        form = PurgeCloudflareCacheForm(request.POST)
+        if form.is_valid():
+            urls = []
+            errors = []
+            for item in form.cleaned_data['pages'].splitlines():
+                try:
+                    url = get_purge_cache_url(item)
+                except forms.ValidationError as error:
+                    errors.extend(error.messages)
+                else:
+                    if url:
+                        urls.append(url)
+
+            filter_urls, debug_rows = get_filter_purge_cache_urls_debug(form.cleaned_data)
+            urls.extend(filter_urls)
+            urls = list(dict.fromkeys(urls))
+            is_preview = 'preview' in request.POST
+
+            if errors:
+                for error in errors:
+                    messages.error(request, error)
+                return render(
+                    request,
+                    'core/admin/purge_cloudflare_cache.html',
+                    {
+                        'form': form,
+                        'debug_rows': debug_rows,
+                        'preview_urls': urls,
+                    },
+                )
+            elif not urls:
+                if form.cleaned_data.get('page_types'):
+                    messages.error(request, 'No live public pages matched those filters.')
+                else:
+                    messages.error(request, 'Enter at least one page to purge.')
+                return render(
+                    request,
+                    'core/admin/purge_cloudflare_cache.html',
+                    {
+                        'form': form,
+                        'debug_rows': debug_rows,
+                    },
+                )
+            elif is_preview:
+                messages.info(request, f'Preview found {len(urls)} URL{"s" if len(urls) != 1 else ""}. Nothing was purged.')
+                return render(
+                    request,
+                    'core/admin/purge_cloudflare_cache.html',
+                    {
+                        'form': form,
+                        'debug_rows': debug_rows,
+                        'preview_urls': urls,
+                    },
+                )
+            elif not getattr(settings, 'WAGTAILFRONTENDCACHE', None):
+                messages.error(request, 'No WAGTAILFRONTENDCACHE backend is configured.')
+                return render(
+                    request,
+                    'core/admin/purge_cloudflare_cache.html',
+                    {
+                        'form': form,
+                        'debug_rows': debug_rows,
+                        'preview_urls': urls,
+                    },
+                )
+            else:
+                purge_urls_from_cache(urls)
+                messages.success(
+                    request,
+                    f'Purged {len(urls)} URL{"s" if len(urls) != 1 else ""} from Cloudflare.',
+                )
+                return render(
+                    request,
+                    'core/admin/purge_cloudflare_cache.html',
+                    {
+                        'form': form,
+                        'debug_rows': debug_rows,
+                        'purged_urls': urls,
+                    },
+                )
+    else:
+        form = PurgeCloudflareCacheForm()
+
+    return render(request, 'core/admin/purge_cloudflare_cache.html', {'form': form})
+
+
+@hooks.register('register_admin_urls')
+def register_purge_cloudflare_cache_url():
+    return [
+        path(
+            'purge-cloudflare-cache/',
+            purge_cloudflare_cache_view,
+            name='purge_cloudflare_cache',
+        ),
+    ]
+
+
+@hooks.register('register_settings_menu_item')
+def register_purge_cloudflare_cache_menu_item():
+    return MenuItem(
+        'Purge Cloudflare Cache',
+        reverse('purge_cloudflare_cache'),
+        icon_name='rotate',
+        order=10000,
+    )
 
 
 @hooks.register('construct_page_chooser_queryset')

--- a/templates/core/admin/purge_cloudflare_cache.html
+++ b/templates/core/admin/purge_cloudflare_cache.html
@@ -1,0 +1,336 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+
+{% block titletag %}{% trans "Purge Cloudflare Cache" %}{% endblock %}
+
+{% block extra_css %}
+  {{ block.super }}
+  <style>
+    .purge-cache-admin textarea {
+      max-width: 48rem;
+    }
+
+    .purge-cache-admin .fields {
+      margin-bottom: 1.5rem;
+    }
+
+    .purge-cache-admin__filters {
+      margin-top: 1.5rem;
+      max-width: 70rem;
+    }
+
+    .purge-cache-admin__filters h2 {
+      margin-bottom: 1rem;
+    }
+
+    .purge-cache-admin__filter-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    }
+
+    .purge-cache-admin__filter-panel {
+      background: #fff;
+      border: 1px solid #d9d9d9;
+      border-radius: 3px;
+      color: #262626;
+      padding: 1rem;
+    }
+
+    .purge-cache-admin__filter-panel .field,
+    .purge-cache-admin__filter-panel label {
+      color: #262626;
+    }
+
+    .purge-cache-admin__filter-panel .field > label {
+      display: block;
+      font-weight: 700;
+      margin-bottom: 0.75rem;
+    }
+
+    .purge-cache-admin__filter-panel ul {
+      display: grid;
+      gap: 0.4rem 0.75rem;
+      grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+      list-style: none;
+      margin: 0;
+      max-height: 16rem;
+      overflow: auto;
+      padding: 0;
+    }
+
+    .purge-cache-admin__filter-panel li {
+      margin: 0;
+    }
+
+    .purge-cache-admin__filter-panel li label {
+      align-items: flex-start;
+      display: flex;
+      gap: 0.45rem;
+      line-height: 1.35;
+    }
+
+    .purge-cache-admin__filter-panel input[type='checkbox'] {
+      flex: 0 0 auto;
+      margin-top: 0.15rem;
+    }
+
+    .purge-cache-admin__results {
+      background: #fff;
+      border: 1px solid #d9d9d9;
+      border-radius: 3px;
+      color: #262626;
+      margin-bottom: 1.5rem;
+      max-width: 70rem;
+      padding: 1rem;
+    }
+
+    .purge-cache-admin__results h2 {
+      margin-bottom: 0.75rem;
+      margin-top: 0;
+    }
+
+    .purge-cache-admin__results ol {
+      margin-bottom: 0;
+      max-height: 20rem;
+      overflow: auto;
+      padding-left: 1.5rem;
+    }
+
+    .purge-cache-admin__results li {
+      line-height: 1.4;
+      margin-bottom: 0.4rem;
+      word-break: break-all;
+    }
+
+    .purge-cache-admin__debug {
+      background: #fff;
+      border: 1px solid #d9d9d9;
+      border-radius: 3px;
+      color: #262626;
+      margin-bottom: 1.5rem;
+      max-width: 70rem;
+      padding: 1rem;
+    }
+
+    .purge-cache-admin__debug h2,
+    .purge-cache-admin__debug h3 {
+      margin-top: 0;
+    }
+
+    .purge-cache-admin__debug-table {
+      margin-bottom: 1rem;
+      width: 100%;
+    }
+
+    .purge-cache-admin__debug-table th,
+    .purge-cache-admin__debug-table td {
+      border-bottom: 1px solid #e5e5e5;
+      color: #262626;
+      padding: 0.5rem;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .purge-cache-admin__debug-sql {
+      background: #f7f7f7;
+      border: 1px solid #e5e5e5;
+      color: #262626;
+      max-height: 12rem;
+      overflow: auto;
+      padding: 0.75rem;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .purge-cache-admin__actions {
+      display: flex;
+      gap: 0.75rem;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <header class="nice-padding">
+    <div class="row">
+      <div class="left">
+        <h1 class="icon icon-rotate title">{% trans "Purge Cloudflare Cache" %}</h1>
+        <p class="help-block title">{% trans "Enter one page URL, path, or Wagtail page ID per line." %}</p>
+      </div>
+    </div>
+  </header>
+
+  <div class="nice-padding purge-cache-admin">
+    {% if purged_urls %}
+      <section class="purge-cache-admin__results">
+        <h2>{% blocktrans count count=purged_urls|length %}Page purged{% plural %}Pages purged{% endblocktrans %}</h2>
+        <ol>
+          {% for url in purged_urls %}
+            <li><a href="{{ url }}" rel="noopener">{{ url }}</a></li>
+          {% endfor %}
+        </ol>
+      </section>
+    {% endif %}
+
+    {% if debug_rows %}
+      <section class="purge-cache-admin__debug">
+        <h2>{% trans "Debug" %}</h2>
+
+        <table class="purge-cache-admin__debug-table">
+          <thead>
+            <tr>
+              <th>{% trans "Page type" %}</th>
+              <th>{% trans "Counts" %}</th>
+              <th>{% trans "Applied filters" %}</th>
+              <th>{% trans "Matches" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in debug_rows %}
+              <tr>
+                <td>{{ row.page_type }}<br><small>{{ row.model }}</small></td>
+                <td>
+                  <strong>{% trans "All" %}:</strong> {{ row.raw_count }}<br>
+                  <strong>{% trans "Live" %}:</strong> {{ row.live_count }}<br>
+                  <strong>{% trans "Live public" %}:</strong> {{ row.public_count }}<br>
+                  <small>{% trans "Purge matching uses live pages." %}</small>
+                </td>
+                <td>
+                  {% for filter in row.filters %}
+                    <strong>{{ filter.label }}:</strong>
+                    {{ filter.values|join:", " }}
+                    <br>
+                    <small>{{ filter.count }} after filter</small>
+                    {% if not forloop.last %}<br>{% endif %}
+                  {% empty %}
+                    {% trans "No optional filters applied." %}
+                  {% endfor %}
+                </td>
+                <td>
+                  <strong>{% trans "Rows" %}:</strong> {{ row.matched_count }}<br>
+                  <strong>{% trans "URLs" %}:</strong> {{ row.url_count }}
+                </td>
+              </tr>
+              <tr>
+                <td colspan="4">
+                  <strong>{% trans "Final query" %}</strong>
+                  <pre class="purge-cache-admin__debug-sql">{{ row.final_sql }}</pre>
+                  {% if row.pages %}
+                    <strong>{% trans "Matched pages" %}</strong>
+                    <ol>
+                      {% for page in row.pages|slice:":25" %}
+                        <li>
+                          {{ page.title }}<br>
+                          <small>
+                            url_path: {{ page.url_path }}<br>
+                            get_full_url: {{ page.full_url|default:"None" }}<br>
+                            purge_url: {{ page.purge_url }}
+                          </small>
+                        </li>
+                      {% endfor %}
+                    </ol>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+
+        {% if preview_urls %}
+          <h3>{% trans "URLs that would be sent" %}</h3>
+          <ol>
+            {% for url in preview_urls %}
+              <li><a href="{{ url }}" rel="noopener">{{ url }}</a></li>
+            {% endfor %}
+          </ol>
+        {% endif %}
+      </section>
+    {% endif %}
+
+    <form method="post" novalidate>
+      {% csrf_token %}
+
+      <ul class="fields">
+        {% for error in form.non_field_errors %}
+          <li><p class="error-message">{{ error }}</p></li>
+        {% endfor %}
+
+        <li>
+          <div class="field char_field text_area">
+            <label for="{{ form.pages.id_for_label }}">{{ form.pages.label }}</label>
+            {{ form.pages }}
+            {% if form.pages.help_text %}
+              <p class="help">{{ form.pages.help_text }}</p>
+            {% endif %}
+            {% for error in form.pages.errors %}
+              <p class="error-message">{{ error }}</p>
+            {% endfor %}
+          </div>
+        </li>
+
+        <li>
+          <section class="purge-cache-admin__filters">
+            <h2>{% trans "Bulk filters" %}</h2>
+
+            <div class="purge-cache-admin__filter-grid">
+              <div class="purge-cache-admin__filter-panel">
+                <div class="field choice_field">
+                  <label>{{ form.page_types.label }}</label>
+                  {{ form.page_types }}
+                  {% for error in form.page_types.errors %}
+                    <p class="error-message">{{ error }}</p>
+                  {% endfor %}
+                </div>
+              </div>
+
+              <div class="purge-cache-admin__filter-panel">
+                <div class="field choice_field">
+                  <label>{{ form.themes.label }}</label>
+                  {{ form.themes }}
+                  {% for error in form.themes.errors %}
+                    <p class="error-message">{{ error }}</p>
+                  {% endfor %}
+                </div>
+              </div>
+
+              <div class="purge-cache-admin__filter-panel">
+                <div class="field choice_field">
+                  <label>{{ form.article_types.label }}</label>
+                  {{ form.article_types }}
+                  {% for error in form.article_types.errors %}
+                    <p class="error-message">{{ error }}</p>
+                  {% endfor %}
+                </div>
+              </div>
+
+              <div class="purge-cache-admin__filter-panel">
+                <div class="field choice_field">
+                  <label>{{ form.publication_types.label }}</label>
+                  {{ form.publication_types }}
+                  {% for error in form.publication_types.errors %}
+                    <p class="error-message">{{ error }}</p>
+                  {% endfor %}
+                </div>
+              </div>
+
+              <div class="purge-cache-admin__filter-panel">
+                <div class="field choice_field">
+                  <label>{{ form.multimedia_types.label }}</label>
+                  {{ form.multimedia_types }}
+                  {% for error in form.multimedia_types.errors %}
+                    <p class="error-message">{{ error }}</p>
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          </section>
+        </li>
+      </ul>
+
+      <div class="purge-cache-admin__actions">
+        <button type="submit" name="preview" value="1" class="button button-secondary">{% trans "Preview matches" %}</button>
+        <button type="submit" class="button">{% trans "Purge cache" %}</button>
+      </div>
+    </form>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Added admin section under Settings that allow automated cloudflare cache purge of pages that meet certain criteria

resolves CIGIHub/cigi-tickets#1177
Fixes/Refs:

## Review Notes

<!-- Point reviewers at the risky or important bits: migrations, data changes, Wagtail/admin behavior, templates, email/reporting flows, frontend states, or anything AI touched heavily. -->

## AI Assistance

<!-- Keep this practical: mention AI-generated/refactored/reviewed areas only when it helps the reviewer know where to look closer. -->

- [ ] No AI assistance used
- [x] AI helped with code, tests, refactoring, debugging, or review
- [x] I reviewed the AI-assisted changes before requesting review

Notes:

## Screenshots / Output

<img width="1014" height="849" alt="image" src="https://github.com/user-attachments/assets/f9ae59e4-9105-44de-8a74-617eadc4c1cc" />
